### PR TITLE
Fix: Use fixed pnpm version

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.14.2 --activate
 COPY ./client /app
 WORKDIR /app
 


### PR DESCRIPTION
### Description

Corepack is used in the client and ran in one of the image build steps. This PR ensures that corepack does not use it's default pnpm version but instead use a fixed version. 

This update sets the pnpm version to `9.14.2`

### Additional Notes
This fixes image builds for the client container.