### PR TITLE
Feat: update user icon and name

### DIFF
--- a/client/src/components/TopNav/TopNav.module.css
+++ b/client/src/components/TopNav/TopNav.module.css
@@ -30,7 +30,7 @@
 }
 
 .avatar {
-  scale: 1.5;
+  scale: 1.3;
   width: 30px;
   height: 30px;
   margin-right: 5px; /* Adjust margin */

--- a/client/src/components/TopNav/TopNav.tsx
+++ b/client/src/components/TopNav/TopNav.tsx
@@ -24,14 +24,14 @@ const SideNav = () => {
         </div>
         <div className={styles.avatarCard}>
           <Avatar
-            src="https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop"
+            src={user && user.picture}
             fallback="A"
             radius="full"
             className={styles.avatar}
           />
 
           <Text as="div" size="1" weight="bold" className={styles.avatarText}>
-            {user && user.email}
+            {user && user.name}
           </Text>
         </div>
       </div>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
This PR is to update the user icon and name in the platform's header.
Currently there was a general image hard coded for the user's picture/icon at the top right corner of the platform. With this change the image will be set to the user's custom picture.

We are able to use the user's picture with the use of Auth0. If the user has a picture set for their existing account (e.g. gmail) then Cascarita will show that same picture. If the user does not have a picture set then the image will appear as abbreviations. Screenshots with this example are below. 
### Issue Link
[CV-56](https://cascarita.atlassian.net/browse/CV-56?atlOrigin=eyJpIjoiNzU1MmE5MWJmMzZlNDYzOWExZDQxMzIxZjgwZTlmMWYiLCJwIjoiaiJ9)
<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally
- [ ] I have added test cases (if applicable)

### Additional Notes
currently:
![Screenshot 2025-02-03 at 3 27 52 PM](https://github.com/user-attachments/assets/07a66435-6fe7-4fe6-bbb5-b679c7945f5a)

updated:
![Screenshot 2025-02-03 at 3 26 51 PM](https://github.com/user-attachments/assets/cf875a8a-69ce-40af-82dd-8e75dd2d3f9d)