### PR TITLE
fix: -webkit-fill-available causing responsiveness issues on Safari

### DIFF
--- a/client/src/components/Page/Page.module.css
+++ b/client/src/components/Page/Page.module.css
@@ -1,10 +1,10 @@
 .page {
   background-color: #fff;
-  width: -webkit-fill-available;
-  width: -moz-available;
   margin-right: 35px;
   border-radius: 6px;
-  height: 87dvh;
+  min-height: 100vh;
+  min-height: -webkit-fill-available;
+  width: 82vw;
   margin-bottom: 35px;
   position: fixed;
   padding: 30px;


### PR DESCRIPTION
### Description

Hi, all:

This pull request addresses a bug with the `-webkit-fill-available` attribute which previously extended the web app's width and height beyond the viewport. 

By editing the `width` and `height` properties of the `Page` component, the page is able to load nicely across most browsers.

<img width="1582" alt="Screenshot 2025-02-04 at 6 19 37 PM" src="https://github.com/user-attachments/assets/4899411d-09d2-45c4-8894-84b3890d42e2" />

The screenshot above was taken in Safari, but this was also tested on Firefox, Edge, and Chrome.

### Issue Link
[[Bug] Page Component Styles #68](https://github.com/cascarita-io/cascarita/issues/68)

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
