### PR TITLE
Fix/Stripe Payment Component Not Rendering

### DIFF
--- a/client/src/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/src/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -13,6 +13,9 @@ import nullthrows from "nullthrows";
 import { useAuth0 } from "@auth0/auth0-react";
 import { DraggableProps } from "../types";
 import { useQuery } from "@tanstack/react-query";
+import Cookies from "js-cookie";
+import { fetchUser } from "../../../api/users/service";
+import { User } from "../../../api/users/types";
 
 const DraggablePayment: React.FC<DraggableProps> = ({
   index,
@@ -20,7 +23,6 @@ const DraggablePayment: React.FC<DraggableProps> = ({
   onDelete,
   onCopy,
 }) => {
-  const { user } = useAuth0();
   const { t } = useTranslation("DraggableFields");
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -28,6 +30,8 @@ const DraggablePayment: React.FC<DraggableProps> = ({
   const [paymentFee, setPaymentFee] = useState(
     formField.properties?.price?.feeValue ?? ""
   );
+
+  const groupId = Number(Cookies.get("group_id")) || 0;
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -39,9 +43,6 @@ const DraggablePayment: React.FC<DraggableProps> = ({
     const fee = price * feePercentage + fixedFee;
     return Math.ceil(fee * 100) / 100;
   };
-
-  // TODO: Make a DB call to get our user related with Auth0 user id
-  const groupId = nullthrows(user?.group_id, "User does not have a group ID");
 
   const { data: stripeAccounts = [], isLoading } = useQuery({
     queryKey: ["stripeAccounts", groupId],

--- a/client/src/components/FormInputComponents/Stripe/StripeComponent.tsx
+++ b/client/src/components/FormInputComponents/Stripe/StripeComponent.tsx
@@ -26,8 +26,9 @@ interface CheckoutFormRef {
 const StripeComponent = forwardRef(({ field, sqlFormId }: FieldProps, ref) => {
   const { t } = useTranslation("FormComponents");
   const [options, setOptions] = useState<StripeElementsOptions | undefined>(
-    undefined,
+    undefined
   );
+  const [paymentIntentCreated, setPaymentIntentCreated] = useState(false);
   const [stripePromise, setStripePromise] = useState<Stripe | null>(null);
   const [clientSecret, setClientSecret] = useState("");
 
@@ -36,13 +37,13 @@ const StripeComponent = forwardRef(({ field, sqlFormId }: FieldProps, ref) => {
   const { data: stripePromiseData } = useStripePromise(
     nullthrows(
       field.properties?.stripe_account?.stripe_account_id,
-      "Stripe Account ID is missing",
-    ),
+      "Stripe Account ID is missing"
+    )
   );
 
   const { mutateAsync: createPaymentIntent } = useCreatePaymentIntent(
     field,
-    nullthrows(sqlFormId, "SQL Form ID is missing"),
+    nullthrows(sqlFormId, "SQL Form ID is missing")
   );
 
   useEffect(() => {
@@ -76,8 +77,9 @@ const StripeComponent = forwardRef(({ field, sqlFormId }: FieldProps, ref) => {
       setStripePromise(stripePromiseData);
     }
 
-    if (stripePromise) {
+    if (stripePromise && !paymentIntentCreated) {
       handleCreatePaymentIntent();
+      setPaymentIntentCreated(true);
     }
   }, [stripePromiseData, stripePromise, createPaymentIntent]);
 

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -77,6 +77,7 @@ const FormController = {
         created_by: req.params.user_id,
         updated_by: null,
         document_id: result.id,
+        form_type: 1, // temp, only type on DB table and allowNull is False
       };
 
       await Form.build(newForm).validate();

--- a/server/models/form.js
+++ b/server/models/form.js
@@ -21,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
         targetKey: "id",
       });
       Form.belongsTo(models.FormType, {
-        foreignKey: "form_type_id",
+        foreignKey: "form_type",
         targetKey: "id",
       });
       Form.hasMany(models.FormPaymentIntents, {
@@ -40,7 +40,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      form_type_id: {
+      form_type: {
         type: DataTypes.INTEGER,
         allowNull: false,
       },

--- a/server/models/formtype.js
+++ b/server/models/formtype.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       FormType.hasMany(models.Form, {
-        foreignKey: "form_type_id",
+        foreignKey: "form_type",
         sourceKey: "id",
       });
     }

--- a/server/seeders/20240902193649-demo-stripe-user.js
+++ b/server/seeders/20240902193649-demo-stripe-user.js
@@ -11,24 +11,12 @@ module.exports = {
         "Groups",
         [
           {
-            name: "Soccer Central",
+            name: "Soccer Central V2",
             street_address: "34 Harkins Slough Rd",
             city: "Watsonville",
             state: "CA",
             zip_code: "95076",
             logo_url: "https://example.com/logo",
-            created_at: new Date(),
-            updated_at: new Date(),
-          },
-        ],
-        { transaction },
-      );
-
-      const role = await queryInterface.bulkInsert(
-        "Roles",
-        [
-          {
-            role_type: "League Owner",
             created_at: new Date(),
             updated_at: new Date(),
           },
@@ -47,9 +35,8 @@ module.exports = {
           first_name: "Raul",
           last_name: "Tester",
           email: "info.cascarita@gmail.com",
-          password: "test",
           group_id: group,
-          role_id: role,
+          role_id: 1, // admin
           language_id: language.id,
           created_at: new Date(),
           updated_at: new Date(),
@@ -65,6 +52,7 @@ module.exports = {
           requires_verification: true,
           charges_enabled: false,
           payouts_enabled: false,
+          stripe_status_id: 4, // 'Enabled'
         },
         { transaction },
       );


### PR DESCRIPTION
### Description


 **Stripe form payment block broken**
- fixed it by using @abanuelo cookie group id solution

**Creating forms is broken  !**
-  FormPayment Table added but column used in the `Forms` table was name 'form_type' on the migration. But models were calling 'form_type_id' so i just made sure the models referencing form type were renamed to `form_type` 
- Since a `form_type` is required, and there is only one default on the database.  I set it as the default value on the controller function where the form is created


### Testing

1. Go to docker desktop -> click cascarita continer -> open the server container -> go to the `Exec`tab -> run seeder file: `npx sequelize-cli db:seed --seed 20240902193649-demo-stripe-user.js`
3. Creat a form with a payment block, drafggin the payment block should not break form builder
4.  Preview form, should see the Stripe Payment Component rendered!
5.  Returning back your db to normal since db changes are branch agnostic, if you checked into this branch changes where done to your database, here is how you can undo them to return to the state before you checked into the branch:
      a. Undo seeder file in `Exec` tab run : `npx sequelize-cli db:seed:undo --seed 20240902193649-demo-stripe-user.js`
 

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
