### PR TITLE
feat: form registration response viewer

### DIFF
--- a/client/src/api/forms/service.ts
+++ b/client/src/api/forms/service.ts
@@ -239,3 +239,57 @@ export const sendEmail = async (formLink: string, email: string) => {
     throw err;
   }
 };
+
+export const getFormPaymentsByPaymentIntentId = async (
+  paymentIntentId: string
+) => {
+  try {
+    const data = {
+      payment_intent_id: paymentIntentId,
+    };
+    const response = await fetch(`/api/forms/payment`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error fetching payment intents: ${response.statusText}`);
+    }
+
+    return response.json();
+  } catch (err) {
+    console.error("Error fetching payment intents:", err);
+    throw err;
+  }
+};
+
+export const updateFormPaymentStatus = async (
+  paymentIntentId: string,
+  status: string
+) => {
+  try {
+    const data = {
+      payment_intent_id: paymentIntentId,
+      status: status,
+    };
+    const response = await fetch(`/api/forms/status`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error fetching payment intents: ${response.statusText}`);
+    }
+
+    return response.json();
+  } catch (err) {
+    console.error("Error fetching payment intents:", err);
+    throw err;
+  }
+};

--- a/client/src/api/forms/types.ts
+++ b/client/src/api/forms/types.ts
@@ -85,7 +85,6 @@ export interface GetFormsParams {
   order_by?: OrderBy | null;
 }
 
-// TODO: ADD MORE EXPLICIT TYPING AS NEEDED
 export type AnswerType =
   | "short_text"
   | "long_text"
@@ -103,6 +102,13 @@ export type AnswerType =
   | "payment"
   | "player";
 
+export type SecondaryType =
+  | "first_name"
+  | "last_name"
+  | "age"
+  | "address"
+  | "team_name";
+
 export interface Answer {
   field: {
     id: string;
@@ -110,6 +116,7 @@ export interface Answer {
     ref: string;
   };
   type: AnswerType;
+  secondary_type?: SecondaryType;
   number?: number;
   short_text?: string;
   long_text?: string;
@@ -117,12 +124,18 @@ export interface Answer {
   liability?: boolean;
   signature?: string;
   email?: string;
-  date?: Date;
+  date?: string;
   boolean?: boolean;
   choice?: { label: string };
   choices?: { labels: string[] };
   file_url?: string;
   player?: {
+    season_name: string;
+    league_name: string;
+    season_id: number | null;
+    league_id: number | null;
+    division_name: string;
+    team_name: string;
     division_id: number | null;
     team_id: number | null;
   };

--- a/client/src/api/forms/types.ts
+++ b/client/src/api/forms/types.ts
@@ -142,4 +142,5 @@ export interface Answer {
   payment?: string;
   paymentIntentId?: string;
   amount?: number;
+  payment_intent_capture_by?: string;
 }

--- a/client/src/components/DashboardTable/DashboardTable.tsx
+++ b/client/src/components/DashboardTable/DashboardTable.tsx
@@ -25,19 +25,20 @@ const DashboardTable: React.FC<TableProps> = ({
   return (
     <div className={styles.tableContainer}>
       <table className={tableStyles}>
-        <thead>
+        <thead
+          style={{
+            position: "sticky",
+            top: 0,
+            background: headColor,
+            zIndex: 1,
+          }}
+        >
           <tr>
-            {headers.map((header, idx) => {
-              return (
-                <th
-                  key={idx}
-                  className={styles.header}
-                  style={{ backgroundColor: headColor }}
-                >
-                  {header}
-                </th>
-              );
-            })}
+            {headers.map((header, idx) => (
+              <th key={idx} className={styles.header}>
+                {header}
+              </th>
+            ))}
           </tr>
         </thead>
 

--- a/client/src/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/src/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -9,13 +9,9 @@ import { useTranslation } from "react-i18next";
 import { SMALL_DRAGGABLE_CONTAINER_WIDTH } from "../constants";
 import { formatPayment } from "../../../utils/formatPayment";
 import { getStripeAccounts } from "../../../api/stripe/service";
-import nullthrows from "nullthrows";
-import { useAuth0 } from "@auth0/auth0-react";
 import { DraggableProps } from "../types";
 import { useQuery } from "@tanstack/react-query";
 import Cookies from "js-cookie";
-import { fetchUser } from "../../../api/users/service";
-import { User } from "../../../api/users/types";
 
 const DraggablePayment: React.FC<DraggableProps> = ({
   index,

--- a/client/src/components/DropdownMenuButton/DropdownMenuButton.module.css
+++ b/client/src/components/DropdownMenuButton/DropdownMenuButton.module.css
@@ -7,7 +7,8 @@
   padding-right: 8px;
   padding-top: 6px;
   padding-bottom: 6px;
-  width: 100px;
+  min-width: 100px;
+  max-width: 150px;
   text-align: center;
 }
 

--- a/client/src/components/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/client/src/components/DropdownMenuButton/DropdownMenuButton.tsx
@@ -7,7 +7,7 @@ import { DropdownMenuButtonProps } from "./types";
 const DropdownMenuButton: React.FC<DropdownMenuButtonProps> & {
   Separator: typeof DropdownMenu.DropdownMenuSeparator;
   Item: typeof DropdownMenu.DropdownMenuItem;
-} = ({ onEdit, onDelete, children }) => {
+} = ({ onEdit, onDelete, onView, children }) => {
   const { t } = useTranslation("DropdownMenuButton");
 
   return (
@@ -38,7 +38,7 @@ const DropdownMenuButton: React.FC<DropdownMenuButtonProps> & {
                 className={styles.seperator}
               />
 
-              <DropdownMenu.DropdownMenuItem>
+              <DropdownMenu.DropdownMenuItem onSelect={onView}>
                 {t("option3")}
               </DropdownMenu.DropdownMenuItem>
             </>

--- a/client/src/components/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/client/src/components/DropdownMenuButton/DropdownMenuButton.tsx
@@ -7,14 +7,14 @@ import { DropdownMenuButtonProps } from "./types";
 const DropdownMenuButton: React.FC<DropdownMenuButtonProps> & {
   Separator: typeof DropdownMenu.DropdownMenuSeparator;
   Item: typeof DropdownMenu.DropdownMenuItem;
-} = ({ onEdit, onDelete, onView, children }) => {
+} = ({ onEdit, onDelete, onView, children, trigger }) => {
   const { t } = useTranslation("DropdownMenuButton");
 
   return (
     <div>
       <DropdownMenu.DropdownMenu>
         <DropdownMenu.DropdownMenuTrigger>
-          <SlOptions />
+          {trigger ? trigger : <SlOptions />}
         </DropdownMenu.DropdownMenuTrigger>
 
         <DropdownMenu.DropdownMenuContent className={styles.options}>

--- a/client/src/components/DropdownMenuButton/types.ts
+++ b/client/src/components/DropdownMenuButton/types.ts
@@ -1,6 +1,7 @@
 interface DropdownMenuButtonProps {
   onEdit?: () => void;
   onDelete?: () => void;
+  onView?: () => void;
   children?: React.ReactNode;
 }
 

--- a/client/src/components/DropdownMenuButton/types.ts
+++ b/client/src/components/DropdownMenuButton/types.ts
@@ -3,6 +3,7 @@ interface DropdownMenuButtonProps {
   onDelete?: () => void;
   onView?: () => void;
   children?: React.ReactNode;
+  trigger?: React.ReactNode;
 }
 
 interface DropdownMenuItemProps {

--- a/client/src/components/FormInputComponents/PlayerBlock/PlayerBlock.tsx
+++ b/client/src/components/FormInputComponents/PlayerBlock/PlayerBlock.tsx
@@ -25,15 +25,33 @@ const PlayerBlock = ({ field, index }: FieldProps) => {
         <div>
           <h4 className={styles.question}>League</h4>
           <p>{field.league_name}</p>
-          <p hidden {...register(`answers.${index}.player.league_id`)}>
-            {field.league_id}
-          </p>
+          <input
+            type="hidden"
+            {...register(`answers.${index}.player.league_name`, {
+              value: field.league_name,
+            })}
+          />
+          <input
+            type="hidden"
+            {...register(`answers.${index}.player.league_id`, {
+              value: field.league_id,
+            })}
+          />
 
           <h4 className={styles.question}>Season</h4>
           <p>{field.season_name}</p>
-          <p hidden {...register(`answers.${index}.player.season_id`)}>
-            {field.season_id}
-          </p>
+          <input
+            type="hidden"
+            {...register(`answers.${index}.player.season_name`, {
+              value: field.season_name,
+            })}
+          />
+          <input
+            type="hidden"
+            {...register(`answers.${index}.player.season_id`, {
+              value: field.season_id,
+            })}
+          />
         </div>
         <div style={{ display: "flex" }}>
           <h4 className={styles.question}>Division</h4>
@@ -47,6 +65,17 @@ const PlayerBlock = ({ field, index }: FieldProps) => {
           className={styles.input}
           {...register(`answers.${index}.player.division_id`, {
             required: required && t("required"),
+            onChange: (e) => {
+              const selectedDivision =
+                field.properties?.player_block_choices?.find(
+                  (choice) => choice.division_id === e.target.value
+                );
+              if (selectedDivision) {
+                register(`answers.${index}.player.division_name`).onChange({
+                  target: { value: selectedDivision.division_name },
+                });
+              }
+            },
           })}
         >
           <option value="">{t("dropdown.placeholder")}</option>
@@ -68,6 +97,16 @@ const PlayerBlock = ({ field, index }: FieldProps) => {
           className={styles.input}
           {...register(`answers.${index}.player.team_id`, {
             required: required && t("required"),
+            onChange: (e) => {
+              const selectedTeam = field.properties?.player_block_choices
+                ?.flatMap((choice) => choice.teams)
+                .find((team: ShortTeam) => team.team_id === e.target.value);
+              if (selectedTeam) {
+                register(`answers.${index}.player.team_name`).onChange({
+                  target: { value: selectedTeam.team_name },
+                });
+              }
+            },
           })}
         >
           <option value="">{t("dropdown.placeholder")}</option>

--- a/client/src/components/FormResponses/FormResponses.module.css
+++ b/client/src/components/FormResponses/FormResponses.module.css
@@ -13,28 +13,22 @@
 .table th {
   /* Apply both top and bottom borders to the <th> */
   padding: 8px;
-  border-top: 2px solid black;
-  border-bottom: 2px solid black;
-  border-right: 2px solid black;
+  text-align: center;
 }
 
 .table td {
   padding: 8px;
   text-align: left;
-  min-width: 150px; /* Set minimum width for cells */
+  min-width: 20px; /* Set minimum width for cells */
   /* Apply both top and bottom borders to the <th> */
   border-bottom: 1px solid #ddd;
   border-right: 1px solid #ddd;
+  text-align: center;
 }
 
 .table td:first-child {
   /* Apply a left border on the first <td> or <th> in a row */
   border-left: 1px solid #ddd;
-}
-
-.table th:first-child {
-  /* Apply a left border on the first <td> or <th> in a row */
-  border-left: 2px solid black;
 }
 
 .table th {
@@ -52,4 +46,10 @@
   display: flex;
   justify-content: center;
   padding: 10px;
+}
+
+.primaryBtn {
+  padding: 5px;
+  border-radius: 30px;
+  width: 70px;
 }

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -52,6 +52,11 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
     return date.toLocaleDateString(undefined, options);
   };
 
+  const formatMoney = (amount: number): string => {
+    //formats cents to dollars
+    return `$${(amount / 100).toFixed(2)}`;
+  };
+
   useEffect(() => {
     (async () => {
       const formData = await getMongoFormById(formId);
@@ -238,7 +243,7 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
             </td>
             <td>{formatDate(submittedAt[index])}</td>
             <td>{email[index]}</td>
-            <td>{amount[index]}</td>
+            <td>{formatMoney(amount[index])}</td>
             <td>
               {paymentType[index] === "Credit Card / Stripe"
                 ? formatDate(submittedAt[index], 3)

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -8,8 +8,10 @@ import {
 import { truncateText } from "../../utils/truncateText";
 import { useTranslation } from "react-i18next";
 import { Answer, Field } from "../../api/forms/types";
+import StatusLabel from "../StatusLabel/StatusLabel";
 
 const FormResponses = ({ formId }: FormResponsesProps) => {
+  const [formType, setFormType] = useState(0);
   const [formFields, setFormFields] = useState<Field[]>([]);
   const [formResponsesMap, setFormResponsesMap] = useState<AnswerRecordMap>(
     new Map()
@@ -19,7 +21,7 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
   useEffect(() => {
     (async () => {
       const formData = await getMongoFormById(formId);
-
+      setFormType(formData.form_type);
       setFormFields(formData.form_data.fields);
       const responsesData = await getMongoFormResponses(formData._id);
       const responsesMap = responsesData.reduce(
@@ -66,6 +68,7 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
       <table className={styles.table}>
         <thead>
           <tr>
+            {formType === 1 && <th>Status</th>}
             {formFields.map((field) => (
               <th key={field.id} title={field.title}>
                 <p>{truncateText(field.title, 35)}</p>
@@ -76,6 +79,11 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
         <tbody>
           {Array.from(formResponsesMap.keys()).map((responseId) => (
             <tr key={responseId}>
+              {formType === 1 && (
+                <td>
+                  <StatusLabel status="pending">pending</StatusLabel>
+                </td>
+              )}
               {formFields.map((field) => (
                 <td key={field.id}>
                   {formResponsesMap.get(responseId)?.get(field.id)?.type &&

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -5,25 +5,58 @@ import {
   getMongoFormById,
   getMongoFormResponses,
 } from "../../api/forms/service";
-import { truncateText } from "../../utils/truncateText";
+// import { truncateText } from "../../utils/truncateText";
 import { useTranslation } from "react-i18next";
 import { Answer, Field } from "../../api/forms/types";
 import StatusLabel from "../StatusLabel/StatusLabel";
+import DashboardTable from "../DashboardTable/DashboardTable";
+// import { set } from "react-hook-form";
+import DropdownMenuButton from "../DropdownMenuButton/DropdownMenuButton";
+import PrimaryButton from "../PrimaryButton/PrimaryButton";
+import Modal from "../Modal/Modal";
+
+const StatusButton = (status: "approved" | "rejected" | "pending") => {
+  return <StatusLabel status={status}>{status}</StatusLabel>;
+};
 
 const FormResponses = ({ formId }: FormResponsesProps) => {
   const [formType, setFormType] = useState(0);
   const [formFields, setFormFields] = useState<Field[]>([]);
+  const [createdAt, setCreatedAt] = useState<string[]>([]);
+  const [createdBy, setCreatedBy] = useState<string[]>([]);
+  const [email, setEmail] = useState<string[]>([]);
+  const [isViewOpen, setIsViewOpen] = useState(false);
+  const [status, setStatus] = useState<("approved" | "rejected" | "pending")[]>(
+    []
+  );
   const [formResponsesMap, setFormResponsesMap] = useState<AnswerRecordMap>(
     new Map()
   );
   const { t } = useTranslation("FormResponses");
 
+  const formatDate = (dateString: string): string => {
+    const options: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    };
+    return new Date(dateString).toLocaleDateString(undefined, options);
+  };
+
   useEffect(() => {
     (async () => {
       const formData = await getMongoFormById(formId);
+      console.log("formData: ", formData);
+      // setEmail(formData.created_by.email);
+      // setCreatedAt(formatDate(formData.createdAt));
+      // setCreatedBy(
+      //   `${formData.created_by.first_name} ${formData.created_by.last_name}`
+      // );
       setFormType(formData.form_type);
       setFormFields(formData.form_data.fields);
+      console.log(formFields);
       const responsesData = await getMongoFormResponses(formData._id);
+      console.log("responsesData", responsesData);
       const responsesMap = responsesData.reduce(
         (result: AnswerRecordMap, res: FormResponse) => {
           const answersMap: Map<string, Answer> = new Map();
@@ -39,63 +72,124 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
       );
 
       setFormResponsesMap(responsesMap);
+      // TODO: add logic to get current status
+      setStatus(responsesData.map(() => "pending"));
+      setCreatedAt(
+        responsesData.map((res: FormResponse) => formatDate(res.createdAt))
+      );
+      // TODO: MAKE SURE TO GET THE STATUS
+      setCreatedBy(responsesData.map(() => "test"));
+      setEmail(responsesData.map(() => "test@test.com"));
     })();
   }, [formId]);
 
-  const formatAnswer = (answer: Answer) => {
-    const typeFormatters: Record<string, () => string | JSX.Element> = {
-      short_text: () => answer.short_text ?? "",
-      long_text: () => answer.long_text ?? "",
-      number: () => String(answer.number ?? ""),
-      email: () => answer.email ?? "",
-      phone_number: () => answer.phone_number ?? "",
-      choice: () => answer.choice?.label ?? "",
-      choices: () => answer.choices?.labels.join(", ") ?? "",
-      date: () =>
-        answer.date ? new Date(answer.date).toLocaleDateString() : "",
-      file_url: () =>
-        answer.file_url ? <a href={answer.file_url}>{t("fileText")}</a> : "",
-      boolean: () =>
-        answer.boolean ? t("booleanOption.true") : t("booleanOption.false"),
-      default: () => "",
+  // const formatAnswer = (answer: Answer) => {
+  //   const typeFormatters: Record<string, () => string | JSX.Element> = {
+  //     short_text: () => answer.short_text ?? "",
+  //     long_text: () => answer.long_text ?? "",
+  //     number: () => String(answer.number ?? ""),
+  //     email: () => answer.email ?? "",
+  //     phone_number: () => answer.phone_number ?? "",
+  //     choice: () => answer.choice?.label ?? "",
+  //     choices: () => answer.choices?.labels.join(", ") ?? "",
+  //     date: () =>
+  //       answer.date ? new Date(answer.date).toLocaleDateString() : "",
+  //     file_url: () =>
+  //       answer.file_url ? <a href={answer.file_url}>{t("fileText")}</a> : "",
+  //     boolean: () =>
+  //       answer.boolean ? t("booleanOption.true") : t("booleanOption.false"),
+  //     default: () => "",
+  //   };
+
+  //   return (typeFormatters[answer.type] ?? typeFormatters.default)();
+  // };
+
+  const handleStatusChange =
+    (index: number, statusUpdate: "approved" | "rejected" | "pending") =>
+    () => {
+      const newStatus = [...status];
+      newStatus[index] = statusUpdate;
+      setStatus(newStatus);
     };
 
-    return (typeFormatters[answer.type] ?? typeFormatters.default)();
-  };
+  const headers = [
+    "#",
+    "Name",
+    "Status",
+    "View Response",
+    "Date Submitted",
+    "Email",
+  ];
 
   return (
     <div className={styles.container}>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            {formType === 1 && <th>Status</th>}
-            {formFields.map((field) => (
-              <th key={field.id} title={field.title}>
-                <p>{truncateText(field.title, 35)}</p>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {Array.from(formResponsesMap.keys()).map((responseId) => (
-            <tr key={responseId}>
-              {formType === 1 && (
-                <td>
+      <DashboardTable
+        headers={headers}
+        headerColor="light"
+        className={styles.table}
+      >
+        {Array.from(formResponsesMap.keys()).map((responseId, index) => (
+          <tr key={responseId}>
+            <td>{index + 1}</td>
+            <td>{createdBy[index]}</td>
+            {formType === 1 && (
+              <td>
+                {/* <button onClick={handleStatusChange(index)}>
                   <StatusLabel status="pending">pending</StatusLabel>
-                </td>
-              )}
-              {formFields.map((field) => (
-                <td key={field.id}>
-                  {formResponsesMap.get(responseId)?.get(field.id)?.type &&
-                    formatAnswer(
-                      formResponsesMap.get(responseId)?.get(field.id) as Answer
-                    )}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                </button> */}
+                <DropdownMenuButton trigger={StatusButton(status[index])}>
+                  <DropdownMenuButton.Item
+                    onClick={handleStatusChange(index, "approved")}
+                  >
+                    <StatusLabel status="approved">approved</StatusLabel>
+                  </DropdownMenuButton.Item>
+
+                  <DropdownMenuButton.Separator className={styles.separator} />
+
+                  <DropdownMenuButton.Item
+                    onClick={handleStatusChange(index, "rejected")}
+                  >
+                    <StatusLabel status="rejected">rejected</StatusLabel>
+                  </DropdownMenuButton.Item>
+
+                  <DropdownMenuButton.Separator className={styles.separator} />
+
+                  <DropdownMenuButton.Item
+                    onClick={handleStatusChange(index, "pending")}
+                  >
+                    <StatusLabel status="pending">pending</StatusLabel>
+                  </DropdownMenuButton.Item>
+                </DropdownMenuButton>
+              </td>
+            )}
+            <td>
+              <Modal open={isViewOpen} onOpenChange={setIsViewOpen}>
+                <Modal.Button asChild className={styles.modalTrigger}>
+                  <PrimaryButton
+                    className={styles.primaryBtn}
+                    onClick={() => setIsViewOpen(true)}
+                  >
+                    <p className={styles.btnTextDesktop}>View</p>
+                  </PrimaryButton>
+                </Modal.Button>
+                <Modal.Content title="test">
+                  <></>
+                </Modal.Content>
+              </Modal>
+            </td>
+            <td>{createdAt[index]}</td>
+            <td>{email[index]}</td>
+            {/* {formFields.map((field) => (
+              <td key={field.id}>
+                {formResponsesMap.get(responseId)?.get(field.id)?.type &&
+                  formatAnswer(
+                    formResponsesMap.get(responseId)?.get(field.id) as Answer
+                  )}
+              </td>
+            ))} */}
+          </tr>
+        ))}
+      </DashboardTable>
       {formResponsesMap.size === 0 && (
         <div className={styles.emptyFormResponses}>
           <h2>{t("noResponsesText")}</h2>

--- a/client/src/components/FormResponses/types.ts
+++ b/client/src/components/FormResponses/types.ts
@@ -28,6 +28,7 @@ export interface TypeformResponse {
 
 export interface FormResponse {
   _id: string;
+  createdAt: string;
   form_id: string;
   response: TypeformResponse;
 }

--- a/client/src/components/FormResponses/types.ts
+++ b/client/src/components/FormResponses/types.ts
@@ -50,4 +50,4 @@ export interface FormResponsesProps {
   formId: string;
 }
 
-export type AnswerRecordMap = Map<string, Map<string, Answer>>;
+export type AnswerRecordMap = Record<string, Answer>[];

--- a/client/src/components/Forms/FormResponseModal/FormResponseModal.module.css
+++ b/client/src/components/Forms/FormResponseModal/FormResponseModal.module.css
@@ -1,0 +1,37 @@
+.table {
+  width: 100%;
+  border-collapse: separate; /* Don't collapse */
+  border-spacing: 0;
+}
+
+.table th {
+  /* Apply both top and bottom borders to the <th> */
+  padding: 8px;
+  text-align: center;
+}
+
+.table td {
+  padding: 8px;
+  text-align: left;
+  min-width: 20px; /* Set minimum width for cells */
+  /* Apply both top and bottom borders to the <th> */
+  border-bottom: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  text-align: center;
+}
+
+.table td:first-child {
+  /* Apply a left border on the first <td> or <th> in a row */
+  border-left: 1px solid #ddd;
+}
+
+.table th {
+  background-color: #f2f2f2;
+  position: sticky;
+  top: 0; /* Stick the header to the top */
+  z-index: 1; /* Ensure the header stays above table rows */
+}
+
+.table tbody tr:nth-child(even) {
+  background-color: #f2f2f2;
+}

--- a/client/src/components/Forms/FormResponseModal/FormResponseModal.tsx
+++ b/client/src/components/Forms/FormResponseModal/FormResponseModal.tsx
@@ -3,12 +3,11 @@ import DashboardTable from "../../DashboardTable/DashboardTable";
 import styles from "./FormResponseModal.module.css";
 
 interface FormResponseModalProps {
-  answers: Map<string, Answer> | undefined;
+  answers: Record<string, Answer> | undefined;
 }
 
 const FormResponseModal: React.FC<FormResponseModalProps> = ({ answers }) => {
-  console.log("answers: ", answers);
-  const headers = answers ? Array.from(answers.keys()) : [];
+  const headers = answers ? Object.keys(answers) : [];
 
   if (headers.includes("player")) {
     const playerIndex = headers.indexOf("player");
@@ -22,32 +21,34 @@ const FormResponseModal: React.FC<FormResponseModalProps> = ({ answers }) => {
     >
       <tr>
         {answers &&
-          Array.from(answers.entries()).map(([key, response]) => (
-            <>
-              {key === "first_name" && <td>{response.short_text}</td>}
-              {key === "last_name" && <td>{response.short_text}</td>}
-              {key === "email" && <td>{response.email}</td>}
-              {key === "phone_number" && <td>{response.phone_number}</td>}
-              {key === "date" && <td> {response.date}</td>}
-              {key === "age" && <td>{response.short_text}</td>}
-              {key === "address" && <td>{response.long_text}</td>}
-              {key === "team_name" && <td>{response.short_text}</td>}
-              {key === "liability" && (
-                <td>{response.liability ? "Yes" : "No"}</td>
-              )}
-              {key === "signature" && <td>{response.short_text}</td>}
-              {key === "player" && (
-                <>
-                  <td>{response.player?.league_name}</td>
-                  <td>{response.player?.season_name}</td>
-                  <td>{response.player?.division_name}</td>
-                  <td>{response.player?.team_name}</td>
-                </>
-              )}
-              {/* TODO: What to add here? */}
-              {key === "payment" && <td>Payment Info</td>}
-            </>
-          ))}
+          Object.keys(answers).map((key) => {
+            const response = answers[key] as Answer;
+            return (
+              <>
+                {key === "first_name" && <td>{response.short_text}</td>}
+                {key === "last_name" && <td>{response.short_text}</td>}
+                {key === "email" && <td>{response.email}</td>}
+                {key === "phone_number" && <td>{response.phone_number}</td>}
+                {key === "date" && <td>{response.date}</td>}
+                {key === "age" && <td>{response.short_text}</td>}
+                {key === "address" && <td>{response.long_text}</td>}
+                {key === "team_name" && <td>{response.short_text}</td>}
+                {key === "liability" && (
+                  <td>{response.liability ? "Yes" : "No"}</td>
+                )}
+                {key === "signature" && <td>{response.short_text}</td>}
+                {key === "player" && (
+                  <>
+                    <td>{response.player?.league_name}</td>
+                    <td>{response.player?.season_name}</td>
+                    <td>{response.player?.division_name}</td>
+                    <td>{response.player?.team_name}</td>
+                  </>
+                )}
+                {key === "payment" && <td>{"No payment data"}</td>}
+              </>
+            );
+          })}
       </tr>
     </DashboardTable>
   );

--- a/client/src/components/Forms/FormResponseModal/FormResponseModal.tsx
+++ b/client/src/components/Forms/FormResponseModal/FormResponseModal.tsx
@@ -1,0 +1,56 @@
+import { Answer } from "../../../api/forms/types";
+import DashboardTable from "../../DashboardTable/DashboardTable";
+import styles from "./FormResponseModal.module.css";
+
+interface FormResponseModalProps {
+  answers: Map<string, Answer> | undefined;
+}
+
+const FormResponseModal: React.FC<FormResponseModalProps> = ({ answers }) => {
+  console.log("answers: ", answers);
+  const headers = answers ? Array.from(answers.keys()) : [];
+
+  if (headers.includes("player")) {
+    const playerIndex = headers.indexOf("player");
+    headers.splice(playerIndex, 1, "league", "season", "division", "team");
+  }
+  return (
+    <DashboardTable
+      headers={headers}
+      headerColor="light"
+      className={styles.table}
+    >
+      <tr>
+        {answers &&
+          Array.from(answers.entries()).map(([key, response]) => (
+            <>
+              {key === "first_name" && <td>{response.short_text}</td>}
+              {key === "last_name" && <td>{response.short_text}</td>}
+              {key === "email" && <td>{response.email}</td>}
+              {key === "phone_number" && <td>{response.phone_number}</td>}
+              {key === "date" && <td> {response.date}</td>}
+              {key === "age" && <td>{response.short_text}</td>}
+              {key === "address" && <td>{response.long_text}</td>}
+              {key === "team_name" && <td>{response.short_text}</td>}
+              {key === "liability" && (
+                <td>{response.liability ? "Yes" : "No"}</td>
+              )}
+              {key === "signature" && <td>{response.short_text}</td>}
+              {key === "player" && (
+                <>
+                  <td>{response.player?.league_name}</td>
+                  <td>{response.player?.season_name}</td>
+                  <td>{response.player?.division_name}</td>
+                  <td>{response.player?.team_name}</td>
+                </>
+              )}
+              {/* TODO: What to add here? */}
+              {key === "payment" && <td>Payment Info</td>}
+            </>
+          ))}
+      </tr>
+    </DashboardTable>
+  );
+};
+
+export default FormResponseModal;

--- a/client/src/components/Forms/RegistrationTemplateForm/RegistrationTemplateForm.tsx
+++ b/client/src/components/Forms/RegistrationTemplateForm/RegistrationTemplateForm.tsx
@@ -170,7 +170,7 @@ const createRegistrationFormData = (
       season_id: seasonId,
       league_name: leagueName,
       league_id: leagueId,
-      validations: { required: true },
+      validations: { required: false },
       properties: {
         player_block_choices: [
           ...divisions.map((division, index) => ({
@@ -377,7 +377,7 @@ const FormTemplateForm: React.FC<RegistrationTemplateFormProps> = ({
     }
 
     if (template !== "registration") {
-      navigate("/forms/check");
+      navigate("/forms/edit");
     } else {
       const data = createRegistrationFormData(
         leagueId,
@@ -403,7 +403,7 @@ const FormTemplateForm: React.FC<RegistrationTemplateFormProps> = ({
         template
       );
 
-      navigate("/forms/check", {
+      navigate("/forms/edit", {
         state: {
           id: form._id,
           title: form.form_data.title,

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -17,6 +17,7 @@ import DeleteForm from "../DeleteForm/DeleteForm";
 import { useTranslation } from "react-i18next";
 import Cookies from "js-cookie";
 import { DivisionType } from "../../../pages/Division/types";
+import { SeasonType } from "../../../pages/Seasons/types";
 
 const TeamForm: React.FC<TeamFormProps> = ({
   afterSave,
@@ -126,7 +127,7 @@ const TeamForm: React.FC<TeamFormProps> = ({
               required={linkToSeason}
             >
               <option value="">Select a season</option>
-              {seasonsData?.map((season: any) => (
+              {seasonsData?.map((season: SeasonType) => (
                 <option key={season.id} value={season.id}>
                   {season.name}
                 </option>

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -14,8 +14,10 @@ const Layout: React.FC<LayoutProps> = () => {
   const [selectedItem, setSelectedItem] = useState("");
 
   const isBlacklisted = blackListRoutes.some((pattern) =>
-    matchPath(window.location.pathname, pattern, blackListExceptions),
+    matchPath(window.location.pathname, pattern, blackListExceptions)
   );
+
+  console.log("isBlacklisted", isBlacklisted);
 
   return (
     <>

--- a/client/src/components/Layout/types.ts
+++ b/client/src/components/Layout/types.ts
@@ -1,4 +1,4 @@
-export const blackListExceptions: string[] = ["/forms/check"];
+export const blackListExceptions: string[] = ["/forms/edit"];
 
 export interface LayoutProps {
   children?: React.ReactNode;

--- a/client/src/components/Modal/Modal.module.css
+++ b/client/src/components/Modal/Modal.module.css
@@ -80,6 +80,31 @@
   outline: none;
 }
 
+.maximizeContent {
+  background-color: white;
+  border-radius: 16px;
+  box-shadow: 1px 1px 1px grey;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  padding: 25px;
+}
+
+.maximizeContent[data-state="open"] {
+  animation: dialog-content-show 200ms;
+  z-index: 2;
+}
+
+.maximizeContent[data-state="closed"] {
+  animation: dialog-content-hide 200ms;
+}
+
+.maximizeContent:focus {
+  outline: none;
+}
+
 .title {
   margin-bottom: 2px;
   font-weight: 700;

--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -14,7 +14,8 @@ const Modal: React.FC<ModalProps> & {
     <Dialog.Root
       open={open}
       onOpenChange={onOpenChange}
-      defaultOpen={defaultOpen}>
+      defaultOpen={defaultOpen}
+    >
       {children}
     </Dialog.Root>
   );
@@ -24,11 +25,14 @@ const ModalContent: React.FC<ModalContentProps> = ({
   title,
   subtitle,
   children,
+  maximize = false,
 }) => {
   return (
     <Dialog.Portal>
       <Dialog.Overlay className={styles.overlay} />
-      <Dialog.Content className={styles.content}>
+      <Dialog.Content
+        className={`${maximize ? styles.maximizeContent : styles.content}`}
+      >
         <Dialog.Title className={styles.title}>{title}</Dialog.Title>
         <Dialog.Description className={styles.subtitle}>
           {subtitle}

--- a/client/src/components/Modal/types.ts
+++ b/client/src/components/Modal/types.ts
@@ -8,6 +8,7 @@ interface ModalProps {
 interface ModalContentProps {
   title?: string;
   subtitle?: string;
+  maximize?: boolean;
   children: React.ReactNode;
 }
 

--- a/client/src/components/StatusLabel/StatusLabel.module.css
+++ b/client/src/components/StatusLabel/StatusLabel.module.css
@@ -1,0 +1,6 @@
+.statusLabel {
+  width: fit-content;
+  font-size: 0.925rem;
+  padding: 1px 16px;
+  border-radius: 30px;
+}

--- a/client/src/components/StatusLabel/StatusLabel.tsx
+++ b/client/src/components/StatusLabel/StatusLabel.tsx
@@ -1,0 +1,33 @@
+import styles from "./StatusLabel.module.css";
+
+export interface StatusLabelProps {
+  status: "approved" | "rejected" | "pending";
+  children: React.ReactNode;
+}
+
+const statusLabelStyling = (status: string) => {
+  return {
+    backgroundColor:
+      status === "approved"
+        ? "#e9ffe8"
+        : status === "rejected"
+          ? "#ffeeee"
+          : "#dbe7f98f",
+    color:
+      status === "approved"
+        ? "#045502"
+        : status === "rejected"
+          ? "#970303"
+          : "#084986",
+  };
+};
+
+const StatusLabel: React.FC<StatusLabelProps> = ({ status, children }) => {
+  return (
+    <p style={statusLabelStyling(status)} className={styles.statusLabel}>
+      {children}
+    </p>
+  );
+};
+
+export default StatusLabel;

--- a/client/src/i18n/en/components/DropdownMenuButton.json
+++ b/client/src/i18n/en/components/DropdownMenuButton.json
@@ -1,5 +1,5 @@
 {
-    "option1": "Edit",
-    "option2": "Delete",
-    "option3": "More"
+  "option1": "Edit",
+  "option2": "Delete",
+  "option3": "View"
 }

--- a/client/src/i18n/en/pages/Settings.json
+++ b/client/src/i18n/en/pages/Settings.json
@@ -38,9 +38,9 @@
     },
     "addStripe": "Add Stripe Account",
     "status": {
-      "complete": "complete",
+      "approved": "approved",
       "pending": "pending",
-      "restricted": "restricted"
+      "rejected": "rejected"
     },
     "empty": "No subscriptions to display...",
     "formContent": {

--- a/client/src/i18n/esp/components/DropdownMenuButton.json
+++ b/client/src/i18n/esp/components/DropdownMenuButton.json
@@ -1,5 +1,5 @@
 {
-    "option1": "Editar",
-    "option2": "Borrar",
-    "option3": "Más"
+  "option1": "Editar",
+  "option2": "Borrar",
+  "option3": "Ver"
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -11,9 +11,7 @@ type AppState = {
 
 const onRedirectCallback = (appState: AppState | undefined) => {
   createBrowserHistory().push(
-    appState && appState.returnTo
-      ? appState.returnTo
-      : window.location.pathname,
+    appState && appState.returnTo ? appState.returnTo : window.location.pathname
   );
 };
 
@@ -42,5 +40,5 @@ createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <App />
     </StrictMode>
-  </Auth0Provider>,
+  </Auth0Provider>
 );

--- a/client/src/pages/FormPage/FormPage.tsx
+++ b/client/src/pages/FormPage/FormPage.tsx
@@ -8,7 +8,12 @@ import { createMongoResponse } from "../../api/forms/service";
 import FormHeader from "../../components/FormHeader/FormHeader";
 import FormFooter from "../../components/FormFooter/FormFooter";
 import styles from "./FormPage.module.css";
-import { Answer, AnswerType, Field } from "../../api/forms/types";
+import {
+  Answer,
+  AnswerType,
+  Field,
+  SecondaryType,
+} from "../../api/forms/types";
 import ProgressBar from "../../components/ProgressBar/ProgressBar";
 
 const FormPage = () => {
@@ -65,11 +70,20 @@ const FormPage = () => {
             ? "choices"
             : (AnswerMap[field.type] as AnswerType);
 
-        return {
-          ...data.answers[index],
-          field: { id: field.id, type: field.type, ref: field.ref },
-          type: answerType,
-        };
+        if (field.secondary_type) {
+          return {
+            ...data.answers[index],
+            field: { id: field.id, type: field.type, ref: field.ref },
+            type: answerType,
+            secondary_type: field.secondary_type as SecondaryType,
+          };
+        } else {
+          return {
+            ...data.answers[index],
+            field: { id: field.id, type: field.type, ref: field.ref },
+            type: answerType,
+          };
+        }
       }) ?? [];
 
     try {

--- a/client/src/pages/FormPage/types.ts
+++ b/client/src/pages/FormPage/types.ts
@@ -44,6 +44,7 @@ export interface FetchedForm {
   };
   welcome_screen: WelcomeScreen;
   sql_form_id: string;
+  form_type: number;
 }
 
 export const FieldComponents = {

--- a/client/src/pages/Forms/Forms.tsx
+++ b/client/src/pages/Forms/Forms.tsx
@@ -23,6 +23,7 @@ import { fetchUser } from "../../api/users/service";
 import { FaPlus } from "react-icons/fa";
 import DashboardTable from "../../components/DashboardTable/DashboardTable";
 import useResponsiveHeader from "../../hooks/useResponsiveHeader";
+import StatusButton from "../../components/StatusLabel/StatusLabel";
 
 interface ShareModalProps {
   formLink: string;
@@ -85,7 +86,7 @@ const Forms = () => {
   }, []);
 
   const handleNewFormClick = () => {
-    navigate("/forms/check");
+    navigate("/forms/view");
   };
 
   const handleShareClick = (formLink: string) => {
@@ -99,10 +100,10 @@ const Forms = () => {
     setForms((forms) => forms.filter((form) => form._id !== id));
   };
 
-  const onEdit = async (id: string) => {
+  const onOpen = async (id: string) => {
     const form = await getMongoFormById(id);
 
-    navigate("/forms/check", {
+    navigate("/forms/edit", {
       state: {
         id,
         title: form.form_data.title,
@@ -112,6 +113,10 @@ const Forms = () => {
         fields: form.form_data.fields,
       },
     });
+  };
+
+  const onView = async (id: string) => {
+    navigate(`/forms/${id}`);
   };
 
   const filteredData = forms
@@ -169,9 +174,15 @@ const Forms = () => {
             <tr key={index} className={styles.tableRow}>
               <td className={styles.tableData}>
                 <p>
-                  <a href={`/forms/${form._id}`} style={{ cursor: "pointer" }}>
+                  <button
+                    onClick={() => onOpen(form._id)}
+                    style={{ cursor: "pointer" }}
+                  >
                     {form.form_data.title}
-                  </a>
+                  </button>
+                  {/* <a href={`/forms/${form._id}`} style={{ cursor: "pointer" }}>
+                    {form.form_data.title}
+                  </a> */}
                 </p>
               </td>
 
@@ -182,7 +193,8 @@ const Forms = () => {
               <td className={`${styles.tableData} ${styles.showInDesktop}`}>
                 <DropdownMenuButton
                   onDelete={() => onDelete(form._id)}
-                  onEdit={() => onEdit(form._id)}
+                  onEdit={() => onOpen(form._id)}
+                  onView={() => onView(form._id)}
                 />
               </td>
 

--- a/client/src/pages/Forms/Forms.tsx
+++ b/client/src/pages/Forms/Forms.tsx
@@ -23,7 +23,6 @@ import { fetchUser } from "../../api/users/service";
 import { FaPlus } from "react-icons/fa";
 import DashboardTable from "../../components/DashboardTable/DashboardTable";
 import useResponsiveHeader from "../../hooks/useResponsiveHeader";
-import StatusButton from "../../components/StatusLabel/StatusLabel";
 
 interface ShareModalProps {
   formLink: string;
@@ -86,7 +85,7 @@ const Forms = () => {
   }, []);
 
   const handleNewFormClick = () => {
-    navigate("/forms/view");
+    navigate("/forms/edit");
   };
 
   const handleShareClick = (formLink: string) => {

--- a/client/src/pages/Routes.tsx
+++ b/client/src/pages/Routes.tsx
@@ -64,7 +64,7 @@ export const useRouter = () =>
             handle={{ crumb: <UserCrumb /> }}
           />
           <Route path="forms" element={<Forms />} />
-          <Route path="forms/check" element={<NewForm />} />
+          <Route path="forms/edit" element={<NewForm />} />
           <Route path="settings" element={<Settings />}>
             <Route index element={<Plan />} />
             <Route path="payment" element={<Payment />} />

--- a/client/src/pages/Settings/Payment/Payment.tsx
+++ b/client/src/pages/Settings/Payment/Payment.tsx
@@ -6,6 +6,7 @@ import Modal from "../../../components/Modal/Modal";
 import PrimaryButton from "../../../components/PrimaryButton/PrimaryButton";
 import StripeAccountForm from "../StripeAccountForm/StripeAccountForm";
 import { useTranslation } from "react-i18next";
+import StatusLabel from "../../../components/StatusLabel/StatusLabel";
 
 const Payment = () => {
   const { t } = useTranslation("Settings");
@@ -18,8 +19,8 @@ const Payment = () => {
   ];
 
   const StatusLabels = {
-    Complete: t("payment.status.complete"),
-    Restricted: t("payment.status.restricted"),
+    Complete: t("payment.status.approved"),
+    Restricted: t("payment.status.rejected"),
     Pending: t("payment.status.pending"),
   };
 
@@ -59,23 +60,6 @@ const Payment = () => {
     return date.toLocaleDateString();
   };
 
-  const statusLabelStyling = (status: string) => {
-    return {
-      backgroundColor:
-        status === StatusLabels.Complete
-          ? "#e9ffe8"
-          : status === StatusLabels.Restricted
-            ? "#ffeeee"
-            : "#dbe7f98f",
-      color:
-        status === StatusLabels.Complete
-          ? "#045502"
-          : status === StatusLabels.Restricted
-            ? "#970303"
-            : "#084986",
-    };
-  };
-
   return (
     <section className={styles.wrapper}>
       <div className={styles.sectionHeader}>
@@ -85,7 +69,8 @@ const Payment = () => {
           <Modal.Button asChild>
             <PrimaryButton
               onClick={() => setIsStripeModalOpen(true)}
-              className={styles.btn}>
+              className={styles.btn}
+            >
               {t("payment.addStripe")}
             </PrimaryButton>
           </Modal.Button>
@@ -104,7 +89,8 @@ const Payment = () => {
       <DashboardTable
         headers={planHeaders}
         headerColor="light"
-        className={styles.table}>
+        className={styles.table}
+      >
         {mockPaymentData == null || mockPaymentData?.length === 0 ? (
           <p>{t("payment.empty")}</p>
         ) : (
@@ -114,11 +100,8 @@ const Payment = () => {
               <td>{user.email}</td>
               <td>{formatDate(user.date_submitted)}</td>
               <td>
-                <p
-                  style={statusLabelStyling(user.status)}
-                  className={`${styles.statusLabel}`}>
-                  {user.status}
-                </p>
+                {/* @ts-ignore */}
+                <StatusLabel status={user.status}>{user.status}</StatusLabel>
               </td>
             </tr>
           ))

--- a/client/src/pages/Settings/Payment/Payment.tsx
+++ b/client/src/pages/Settings/Payment/Payment.tsx
@@ -18,10 +18,10 @@ const Payment = () => {
     t("payment.headers.status"),
   ];
 
-  const StatusLabels = {
-    Complete: t("payment.status.approved"),
-    Restricted: t("payment.status.rejected"),
-    Pending: t("payment.status.pending"),
+  const StatusLabels: { [key: string]: "approved" | "rejected" | "pending" } = {
+    Complete: "approved",
+    Restricted: "rejected",
+    Pending: "pending",
   };
 
   const mockPaymentData = [
@@ -100,7 +100,6 @@ const Payment = () => {
               <td>{user.email}</td>
               <td>{formatDate(user.date_submitted)}</td>
               <td>
-                {/* @ts-ignore */}
                 <StatusLabel status={user.status}>{user.status}</StatusLabel>
               </td>
             </tr>

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -107,6 +107,7 @@ const FormController = {
         data.sql_form_id = sqlFormData
           ? sqlFormData.id
           : `no sql form found for ${form_document_id}`;
+        data.form_type = sqlFormData ? sqlFormData.form_type : 0;
       }
 
       return res.status(200).json(data);

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -124,6 +124,53 @@ const FormPaymentController = {
       throw error;
     }
   },
+
+  async getFormPaymentByPaymentIntentId(req, res, next) {
+    const { payment_intent_id } = req.body;
+    try {
+      const formPayment = await FormPayment.findOne({
+        where: {
+          payment_intent_id: payment_intent_id,
+        },
+      });
+
+      if (!formPayment) {
+        res.status(404);
+        throw new Error(
+          `no form payment record found with payment intent id: ${req.params.payment_intent_id}`,
+        );
+      }
+
+      return res.status(200).json(formPayment);
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  async updatePaymentStatus(req, res, next) {
+    try {
+      const { payment_intent_id, status } = req.body;
+
+      const formPayment = await FormPayment.findOne({
+        where: {
+          payment_intent_id: payment_intent_id,
+        },
+      });
+
+      if (!formPayment) {
+        res.status(404);
+        throw new Error(
+          `no form payment record found with payment intent id: ${payment_intent_id}`,
+        );
+      }
+
+      await formPayment.update({ payment_intent_status: status });
+
+      return res.status(200).json(formPayment);
+    } catch (error) {
+      next(error);
+    }
+  },
 };
 
 module.exports = FormPaymentController;

--- a/server/routes/form.routes.js
+++ b/server/routes/form.routes.js
@@ -3,6 +3,7 @@
 const express = require("express");
 const router = express.Router();
 const FormController = require("../controllers/form.controller");
+const FormPaymentController = require("../controllers/formPayment.controller");
 
 module.exports = (checkJwt) => {
   router.post("/:group_id/:user_id", FormController.createForm);
@@ -11,5 +12,10 @@ module.exports = (checkJwt) => {
   router.get("/:document_id", FormController.getFormByDocumentId);
   router.patch("/:form_id", FormController.updateForm);
   router.delete("/:form_id", FormController.deleteForm);
+  router.post(
+    "/payment",
+    FormPaymentController.getFormPaymentByPaymentIntentId,
+  );
+  router.post("/status", FormPaymentController.updatePaymentStatus);
   return router;
 };


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
For Registration Type forms only, we can see form responses from within the Edit Form viewer

![Recording 2025-02-21 at 00 49 11](https://github.com/user-attachments/assets/d5d134ee-91e6-45b3-95a6-cd7d69a2dcad)

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
- Make responses from admins more intuitive: https://cascarita.atlassian.net/browse/CV-48

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
