### PR TITLE
Feature: Handle Stripe Payments

### DIFF
--- a/client/src/api/forms/service.ts
+++ b/client/src/api/forms/service.ts
@@ -41,7 +41,7 @@ export const updateForm = async (
   formId: string,
   title: string,
   description: string,
-  user: User | null,
+  user: User | null
 ) => {
   const formData = {
     form_data: {
@@ -108,7 +108,7 @@ export const createMongoForm = async (
   title: string,
   description: string,
   groupId: number | undefined,
-  userId: number | undefined,
+  userId: number | undefined
 ) => {
   const formData = {
     title,
@@ -186,7 +186,10 @@ export const getMongoFormResponses = async (formId: string) => {
   }
 };
 
-export const createMongoResponse = async (formId: string, answer: Answer[]) => {
+export const createMongoResponse = async (
+  formId: string,
+  answer: (string | number | Answer)[]
+) => {
   const data = {
     form_id: formId,
     data: answer,

--- a/client/src/api/forms/types.ts
+++ b/client/src/api/forms/types.ts
@@ -106,4 +106,6 @@ export interface Answer {
   choices?: { labels: string[] };
   file_url?: string;
   payment?: string;
+  paymentIntentId?: string;
+  amount?: number;
 }

--- a/client/src/api/stripe/service.ts
+++ b/client/src/api/stripe/service.ts
@@ -32,9 +32,9 @@ export const connectStripe = async (formData: object) => {
 export const createPaymentIntent = async (
   stripeAccountId: string,
   form_id: string,
-  userId: string,
-  price: number,
-  fee: number,
+  userStripeAccountSqlId: string,
+  transactionAmount: number,
+  transactionFee: number
 ): Promise<PaymentIntent | null> => {
   try {
     const response = await fetch(
@@ -45,12 +45,12 @@ export const createPaymentIntent = async (
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          price,
-          fee,
+          transactionAmount,
+          transactionFee,
           form_id,
-          userId,
+          userStripeAccountSqlId,
         }),
-      },
+      }
     );
 
     if (!response.ok) {
@@ -71,7 +71,7 @@ export const getPublishableKey = async (): Promise<string> => {
 
     if (!response.ok) {
       throw new Error(
-        `fetching publishable key non-ok-response: ${response.status} - ${response.statusText}`,
+        `fetching publishable key non-ok-response: ${response.status} - ${response.statusText}`
       );
     }
 
@@ -84,7 +84,7 @@ export const getPublishableKey = async (): Promise<string> => {
 };
 
 export const getStripeAccounts = async (
-  groupId: number,
+  groupId: number
 ): Promise<StripeAccount[]> => {
   try {
     const response = await fetch(`/api/accounts/${groupId}`);
@@ -110,7 +110,7 @@ export const useStripePromise = (stripeAccount: string) => {
         nullthrows(publishableKey, "Publishable key is missing"),
         {
           stripeAccount,
-        },
+        }
       );
     },
   });

--- a/client/src/components/StripeForm/CheckoutForm.tsx
+++ b/client/src/components/StripeForm/CheckoutForm.tsx
@@ -2,8 +2,7 @@ import { PaymentElement } from "@stripe/react-stripe-js";
 import { useState, forwardRef, useImperativeHandle } from "react";
 import { useStripe, useElements } from "@stripe/react-stripe-js";
 import styles from "./CheckoutForm.module.css";
-
-interface PaymentResult {
+export interface PaymentResult {
   success: boolean;
   paymentIntentId?: string;
   amount?: number;

--- a/client/src/pages/FormPage/FormPage.tsx
+++ b/client/src/pages/FormPage/FormPage.tsx
@@ -85,13 +85,21 @@ const FormPage = () => {
         if (!success) {
           return;
         } else {
-          const newArr: (string | number | Answer)[] = [
-            ...normalizedAnswers,
-            paymentIntentId ?? "",
-            amount ?? 0,
-          ];
+          const updatedNormalizedAnswers = normalizedAnswers.map((answer) => {
+            if (answer.type === "payment") {
+              return {
+                ...answer,
+                paymentIntentId: paymentIntentId,
+                amount: amount,
+              };
+            }
+            return answer;
+          });
 
-          const responsesData = await createMongoResponse(formId ?? "", newArr);
+          const responsesData = await createMongoResponse(
+            formId ?? "",
+            updatedNormalizedAnswers
+          );
           // TODO: Redirect to a thank you page!
           navigate("/");
           return responsesData;

--- a/client/src/pages/FormPage/FormPage.tsx
+++ b/client/src/pages/FormPage/FormPage.tsx
@@ -10,12 +10,7 @@ import FormFooter from "../../components/FormFooter/FormFooter";
 import styles from "./FormPage.module.css";
 import { Answer, AnswerType, Field } from "../../api/forms/types";
 import ProgressBar from "../../components/ProgressBar/ProgressBar";
-interface PaymentResult {
-  success: boolean;
-  paymentIntentId?: string;
-  amount?: number;
-  error?: string;
-}
+import { PaymentResult } from "../../components/StripeForm/CheckoutForm";
 
 const FormPage = () => {
   const { formId } = useParams();

--- a/server/controllers/account.controller.js
+++ b/server/controllers/account.controller.js
@@ -82,6 +82,7 @@ const AccountController = function () {
           automatic_payment_methods: {
             enabled: true,
           },
+          capture_method: "manual",
           application_fee_amount: productObj.transactionFee,
         },
         {

--- a/server/controllers/account.controller.js
+++ b/server/controllers/account.controller.js
@@ -5,12 +5,12 @@ require("dotenv").config();
 const Stripe = require("stripe")(process.env.STRIPE_TEST_API_KEY);
 const {
   UserStripeAccounts,
-  FormPaymentIntents,
   User,
   StripeStatus,
   Group,
   FormPayment,
 } = require("../models");
+const FormPaymentController = require("./formPayment.controller");
 const modelByPk = require("./utility");
 
 const AccountController = function () {
@@ -91,9 +91,12 @@ const AccountController = function () {
 
       productObj.paymentIntentId = paymentIntent.id;
       productObj.paymentIntentStatus = paymentIntent.status;
-      await createStripePayemnt(productObj);
+      await FormPaymentController.createStripeFormPayment(productObj);
 
-      return res.status(201).json(paymentIntent);
+      return res.status(200).json({
+        client_secret: paymentIntent.client_secret,
+        //paymentIntentId: paymentIntent.id,
+      });
     } catch (error) {
       console.error(error);
       next(error);
@@ -223,18 +226,6 @@ const AccountController = function () {
 
   const getPublishableKey = function (req, res, next) {
     res.status(200).json({ key: process.env.STRIPE_PUBLISHABLE_KEY });
-  };
-
-  var createStripePayemnt = async function (formData) {
-    await FormPayment.create({
-      form_id: formData.form_id,
-      payment_method_id: 1, //since this go triggred, it is stripe payment
-      internal_status_id: 1, // set it to default 'Pending'
-      amount: formData.transactionAmount,
-      payment_intent_id: formData.paymentIntentId,
-      payment_intent_status: formData.paymentIntentStatus,
-      user_stripe_account_id: formData.userStripeAccountSqlId,
-    });
   };
 
   return {

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -214,38 +214,6 @@ const FormController = {
       next(error);
     }
   },
-
-  async updateStripePayment(paymentIntent) {
-    try {
-      const existingPaymentIntent = await FormPayment.findOne({
-        where: {
-          payment_intent_id: paymentIntent.id,
-        },
-      });
-
-      if (!existingPaymentIntent) {
-        res.status(404);
-        throw new Error(
-          `no form payment record found with payment intent id: ${paymentIntent.id}`,
-        );
-      }
-
-      const updates = {
-        internal_status_id: 2, // set it to 'Awaiting Approval'
-        amount: paymentIntent.amount,
-        payment_intent_status: paymentIntent.status,
-      };
-
-      await existingPaymentIntent.update(updates, { validate: true });
-
-      //TODO: Need to update existing response in the mongo collection
-
-      return true;
-    } catch (error) {
-      console.error(error);
-      return false;
-    }
-  },
 };
 
 module.exports = FormController;

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -4,7 +4,8 @@ require("dotenv").config();
 
 const Response = require("./../mongoModels/response");
 const FormMongo = require("./../mongoModels/form");
-const { Form, User, FormPayment } = require("../models");
+const { Form, User } = require("../models");
+const FormPaymentController = require("./formPayment.controller");
 
 const FormController = {
   async getAllForms(req, res, next) {
@@ -20,14 +21,20 @@ const FormController = {
   },
   async createResponse(req, res, next) {
     try {
+      const responseData = req.body.data;
       const insertedResponse = new Response({
         form_id: req.body.form_id,
         response: {
-          answers: req.body.data,
+          answers: responseData,
         },
       });
 
       await insertedResponse.save();
+      const responseIdString = insertedResponse.id;
+      await FormPaymentController.connectResponseToFormPayment(
+        responseData,
+        responseIdString,
+      );
 
       return res.status(201).json(insertedResponse);
     } catch (error) {

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -1,0 +1,77 @@
+"use strict";
+
+require("dotenv").config();
+
+const { FormPayment } = require("../models");
+
+const FormPaymentController = {
+  async connectResponseToFormPayment(responseData, responseId) {
+    const paymentFieldIndex = responseData.findIndex(
+      (item) => item?.field?.type === "payment",
+    );
+
+    if (!paymentFieldIndex) {
+      return;
+    }
+    try {
+      const paymentIntentId = responseData[paymentFieldIndex + 1];
+
+      let existingFormPayment = await this.findFormPaymentByPaymentIntentId(
+        paymentIntentId,
+      );
+
+      const updates = {
+        response_document_id: responseId,
+      };
+
+      await existingFormPayment.update(updates, { validate: true });
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  },
+
+  async updateStripePayment(paymentIntent) {
+    try {
+      const existingPaymentIntent = await this.findFormPaymentByPaymentIntentId(
+        paymentIntent.id,
+      );
+
+      const updates = {
+        internal_status_id: 2, // set it to 'Awaiting Approval'
+        amount: paymentIntent.amount,
+        payment_intent_status: paymentIntent.status,
+      };
+
+      await existingPaymentIntent.update(updates, { validate: true });
+
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  },
+
+  async findFormPaymentByPaymentIntentId(paymentIntentId) {
+    try {
+      const formPayment = await FormPayment.findOne({
+        where: {
+          payment_intent_id: paymentIntentId,
+        },
+      });
+
+      if (!formPayment) {
+        res.status(404);
+        throw new Error(
+          `no form payment record found with payment intent id: ${paymentIntent.id}`,
+        );
+      }
+
+      return formPayment;
+    } catch (error) {
+      throw error;
+    }
+  },
+};
+
+module.exports = FormPaymentController;

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -52,6 +52,18 @@ const FormPaymentController = {
     }
   },
 
+  async createStripeFormPayment(formData) {
+    await FormPayment.create({
+      form_id: formData.form_id,
+      payment_method_id: 1, //since this go triggred, it is stripe payment
+      internal_status_id: 1, // set it to default 'Pending'
+      amount: formData.transactionAmount,
+      payment_intent_id: formData.paymentIntentId,
+      payment_intent_status: formData.paymentIntentStatus,
+      user_stripe_account_id: formData.userStripeAccountSqlId,
+    });
+  },
+
   async findFormPaymentByPaymentIntentId(paymentIntentId) {
     try {
       const formPayment = await FormPayment.findOne({

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -6,15 +6,15 @@ const { FormPayment } = require("../models");
 
 const FormPaymentController = {
   async connectResponseToFormPayment(responseData, responseId) {
-    const paymentFieldIndex = responseData.findIndex(
-      (item) => item?.field?.type === "payment",
+    const paymentEntry = responseData.find(
+      (item) => item.field?.type === "payment" && item.paymentIntentId,
     );
 
-    if (!paymentFieldIndex) {
+    if (!paymentEntry) {
       return;
     }
     try {
-      const paymentIntentId = responseData[paymentFieldIndex + 1];
+      const paymentIntentId = paymentEntry.paymentIntentId;
 
       let existingFormPayment = await this.findFormPaymentByPaymentIntentId(
         paymentIntentId,

--- a/server/controllers/stripeResources/connectedAccount.controller.js
+++ b/server/controllers/stripeResources/connectedAccount.controller.js
@@ -86,6 +86,7 @@ const ConnectAccountController = function () {
 
   return {
     handleEvent,
+    verifyRequest,
   };
 };
 

--- a/server/controllers/stripeResources/formTransaction.controller.js
+++ b/server/controllers/stripeResources/formTransaction.controller.js
@@ -1,0 +1,48 @@
+"use strict";
+const ConnectedAccountController = require("./connectedAccount.controller");
+const FormController = require("../form.controller");
+
+const FormTransactionController = function () {
+  const endpointSecret = process.env.STRIPE_CONNECTED_ACCOUNTS_WEBHOOK_SECRET;
+
+  var handleEvent = async function (req, res) {
+    try {
+      let event = ConnectedAccountController.verifyRequest(
+        req.body,
+        req.headers["stripe-signature"],
+        endpointSecret,
+      );
+
+      switch (event.type) {
+        case "payment_intent.succeeded":
+          const paymentIntent = event.data.object;
+          const success = await FormController.updateStripePayment(
+            paymentIntent,
+          );
+
+          return res.status(200).json({
+            message: success
+              ? "Payment updated successfully"
+              : "Payment update failed but webhook received",
+          });
+
+        default:
+          console.log(`Unhandled webhook event type: ${event.type}`);
+          return res.status(200).json({
+            message: "Unhandled event type, but webhook received",
+          });
+      }
+    } catch (error) {
+      console.error("Webhook error:", error);
+      return res.status(400).json({
+        message: `Webhook error: ${error.message}`,
+      });
+    }
+  };
+
+  return {
+    handleEvent,
+  };
+};
+
+module.exports = FormTransactionController();

--- a/server/controllers/stripeResources/formTransaction.controller.js
+++ b/server/controllers/stripeResources/formTransaction.controller.js
@@ -14,7 +14,7 @@ const FormTransactionController = function () {
       );
 
       switch (event.type) {
-        case "payment_intent.succeeded":
+        case "payment_intent.amount_capturable_updated":
           const paymentIntent = event.data.object;
           const success = await FormPaymentController.updateStripePayment(
             paymentIntent,
@@ -25,6 +25,8 @@ const FormTransactionController = function () {
               ? "Payment updated successfully"
               : "Payment update failed but webhook received",
           });
+        // @Chuy TODO: When Admin approves a stripe payment then logic can start here !
+        //case "payment_intent.succeeded":
 
         default:
           console.log(`Unhandled webhook event type: ${event.type}`);

--- a/server/controllers/stripeResources/formTransaction.controller.js
+++ b/server/controllers/stripeResources/formTransaction.controller.js
@@ -1,6 +1,6 @@
 "use strict";
 const ConnectedAccountController = require("./connectedAccount.controller");
-const FormController = require("../form.controller");
+const FormPaymentController = require("../formPayment.controller");
 
 const FormTransactionController = function () {
   const endpointSecret = process.env.STRIPE_CONNECTED_ACCOUNTS_WEBHOOK_SECRET;
@@ -16,7 +16,7 @@ const FormTransactionController = function () {
       switch (event.type) {
         case "payment_intent.succeeded":
           const paymentIntent = event.data.object;
-          const success = await FormController.updateStripePayment(
+          const success = await FormPaymentController.updateStripePayment(
             paymentIntent,
           );
 

--- a/server/migrations/20250217210733-update-form-payment-w-user-stripe-account-id-col.js
+++ b/server/migrations/20250217210733-update-form-payment-w-user-stripe-account-id-col.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.addColumn(
+        "FormPayments",
+        "user_stripe_account_id",
+        {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: {
+            model: "UserStripeAccounts",
+            key: "id",
+          },
+          onUpdate: "CASCADE",
+          onDelete: "SET NULL",
+        },
+        { transaction },
+      );
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("FormPayments", "user_stripe_account_id");
+  },
+};

--- a/server/migrations/20250220024603-update-form-payment-w-response-document-id.js
+++ b/server/migrations/20250220024603-update-form-payment-w-response-document-id.js
@@ -1,0 +1,29 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.addColumn(
+        "FormPayments",
+        "response_document_id",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+          unique: true,
+        },
+        { transaction },
+      );
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("FormPayments", "response_document_id");
+  },
+};

--- a/server/models/formpayment.js
+++ b/server/models/formpayment.js
@@ -32,6 +32,11 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: "internal_status_id",
         targetKey: "id",
       });
+
+      FormPayment.belongsTo(models.UserStripeAccounts, {
+        foreignKey: "user_stripe_account_id",
+        targetKey: "id",
+      });
     }
   }
   FormPayment.init(
@@ -83,12 +88,18 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
+      user_stripe_account_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
     },
 
     {
       sequelize,
       modelName: "FormPayment",
       tableName: "FormPayments",
+      createdAt: "created_at",
+      updatedAt: "updated_at",
     },
   );
   return FormPayment;

--- a/server/models/formpayment.js
+++ b/server/models/formpayment.js
@@ -92,6 +92,11 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
+      response_document_id: {
+        type: DataTypes.STRING,
+        allowNull: true,
+        unique: true,
+      },
     },
 
     {

--- a/server/models/userstripeaccounts.js
+++ b/server/models/userstripeaccounts.js
@@ -16,6 +16,10 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: "stripe_status_id",
         targetKey: "id",
       });
+      UserStripeAccounts.belongsTo(models.FormPayment, {
+        foreignKey: "user_stripe_account_id",
+        targetKey: "id",
+      });
     }
   }
   UserStripeAccounts.init(

--- a/server/routes/webhooks/stripe.webhooks.js
+++ b/server/routes/webhooks/stripe.webhooks.js
@@ -2,8 +2,10 @@
 
 const express = require("express");
 const ConnectedAccountController = require("../../controllers/stripeResources/connectedAccount.controller");
+const FormTransactionController = require("../../controllers/stripeResources/formTransaction.controller");
 const router = express.Router();
 
 router.post("/connect", ConnectedAccountController.handleEvent);
+router.post("/payment", FormTransactionController.handleEvent);
 
 module.exports = router;


### PR DESCRIPTION
### Description

This does a couple of things but over all when a form has a payment block and user fills it out we now keep track of it on our database from when they open the stripe payment element to when they entered their card info and submitted the form ! :

1. webhooks for payment intent events , at the moment only handles when a payment intent is submitted (aka: user provides card info)
2. `formpayment.controller.js `file created with functions to : 
- `createStripeFormPayment()` :  creates `FromPayment` record for a form that has a stripe payment element is rendered
- `connectResponseToFormPayment()` : a function to link `FromPayment` record  to a `Response` record from Mongo  collection
- `updateStripePayment()` : a function that gets used by the webhook to update the status of the stripe payment info, for now its when a user fills out the stripe payment element  
- `findFormPaymentByPaymentIntentId()` : a function to look up `FromPayment` record via a `payment_intent_id` 

3. migration to add a new column to the `FormPayments` table to track `Response` (mongo collections) response document ids as strings (for example `123abc` and not the `ObjectId('123abc'`) 
4. front end code to pass back payment intent id*

### NOTE: 
**I need help with the react typescript code** So i need the `payment_intent_id` when a payment is completed on the `FormPage.tsx` , here was my attempt to get the data to request body, could use feedback and refactor help of my solution

commit hash: 01d1eff86adca7fc41d6d23a0e4cf8935fd90032 

### Testing 

- I will have to hop on a call to show you all how to test!

### Issue Link

[Jira Card: CV-75 ](https://cascarita.atlassian.net/browse/CV-75)

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
