### PR TITLE
upgrade datatype for image url columns

### DIFF
--- a/server/migrations/20250222013628-upgrade-image-column-types.js
+++ b/server/migrations/20250222013628-upgrade-image-column-types.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Users', 'picture', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Teams', 'team_logo', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('TeamHistories', 'team_logo', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Groups', 'logo_url', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Players', 'profile_picture', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('PlayerHistories', 'profile_picture', {
+      type: Sequelize.STRING(2083),
+      allowNull: true
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Users', 'picture', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Teams', 'team_logo', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('TeamHistories', 'team_logo', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Groups', 'logo_url', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('Players', 'profile_picture', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+
+    await queryInterface.changeColumn('PlayerHistories', 'profile_picture', {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    });
+  }
+};


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Upgrades the datatype for columns in our tables that store image urls. These columns will be used to store S3 image urls. All of these columns existed but they were VARCHAR(255) which is not long enough for S3 urls, specially not if they are signed urls. 

Tables updated:
- Users
- Teams
- TeamHistories
- Players
- PlayerHistories
- Groups

### Issue Link
Ticket: [CV-82](https://cascarita.atlassian.net/browse/CV-82?atlOrigin=eyJpIjoiZmMxMmZkODRmYTg3NDcwNzliOGQwMzUxMjAzZGM3YWIiLCJwIjoiaiJ9)

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally

### Additional Notes
The maximum URL length supported by most web browsers (especially Internet Explorer) is 2083 characters.