### PR TITLE
Fix: Stripe Account Webhook Broken

### DIFF
--- a/server/controllers/stripeResources/connectedAccount.controller.js
+++ b/server/controllers/stripeResources/connectedAccount.controller.js
@@ -26,23 +26,21 @@ const ConnectAccountController = function () {
         endpointSecret,
       );
 
-      let statusCode = 200;
-      let responseBody = { message: "Event handled!" };
-
       switch (event.type) {
         case "account.updated":
           const accountInfo = event.data.object;
           const updated = await _updateAccount(accountInfo);
-          if (!updated) {
-            statusCode = 500;
-            responseBody = { message: "Error updating account" };
-          }
-          break;
+          return res.status(200).json({
+            message: updated
+              ? "account updated successfully"
+              : "account update failed but webhook received",
+          });
         default:
-          statusCode = 403;
-          responseBody = { message: "Unhandled event type" };
+          console.log(`Unhandled webhook event type: ${event.type}`);
+          return res.status(200).json({
+            message: "Unhandled event type, but webhook received",
+          });
       }
-      return res.status(statusCode).json(responseBody);
     } catch (error) {
       return res.status(400).send(`Webhook Error: ${error.message}`);
     }

--- a/server/models/userstripeaccounts.js
+++ b/server/models/userstripeaccounts.js
@@ -16,9 +16,9 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: "stripe_status_id",
         targetKey: "id",
       });
-      UserStripeAccounts.belongsTo(models.FormPayment, {
+      UserStripeAccounts.hasMany(models.FormPayment, {
         foreignKey: "user_stripe_account_id",
-        targetKey: "id",
+        sourceKey: "id",
       });
     }
   }


### PR DESCRIPTION
### Description

Since the addition of `formPayments` table, the association between this new table and this `UserStripeAccounts` was wrong so when webhooks would get used and it updates the record on the `UserStripeAccount` table it would break

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
