### PR TITLE
Fix/show season in teams

### DIFF
--- a/client/src/api/forms/service.ts
+++ b/client/src/api/forms/service.ts
@@ -270,7 +270,7 @@ export const updateFormPaymentStatus = async (
   paymentIntentId: string,
   status: string,
   email: string,
-  answers: Map<string, Answer>
+  answers: Record<string, Answer>
 ) => {
   try {
     const data = {

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -156,7 +156,7 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
   const handleStatusChange = (
     index: number,
     statusUpdate: "approved" | "rejected" | "pending",
-    response: Map<string, Answer>
+    response: Record<string, Answer>
   ) => {
     return async () => {
       const newStatus = [...status];

--- a/client/src/i18n/en/pages/Teams.json
+++ b/client/src/i18n/en/pages/Teams.json
@@ -21,6 +21,7 @@
   "tableHeaders": {
     "name": "Team Name",
     "division": "Division",
-    "options": "Options"
+    "options": "Options",
+    "season": "Season"
   }
 }

--- a/client/src/pages/Teams/Teams.tsx
+++ b/client/src/pages/Teams/Teams.tsx
@@ -134,6 +134,7 @@ const Teams = () => {
           <DashboardTable
             headers={[
               t("tableHeaders.name"),
+              t("tableHeaders.season"),
               t("tableHeaders.division"),
               t("tableHeaders.options"),
             ]}
@@ -161,6 +162,9 @@ const Teams = () => {
                       <img src={team.team_logo} />
                       {team.name}
                     </div>
+                  </td>
+                  <td>
+                    {team.season_name || <span>Not linked to season</span>}
                   </td>
                   <td>
                     {team.division_name || <span>Not linked to season</span>}

--- a/client/src/pages/Teams/types.ts
+++ b/client/src/pages/Teams/types.ts
@@ -11,6 +11,8 @@ interface TeamType {
   group_id: number;
   division_name: string;
   division_id: number;
+  season_name: string;
+  season_id: number;
 }
 
 export type { TeamType, ShortDivisionType };

--- a/server/controllers/team.controller.js
+++ b/server/controllers/team.controller.js
@@ -1,6 +1,5 @@
 "use strict";
-const { link } = require("../app");
-const { Team, Group, Division, TeamsSession, Session } = require("./../models");
+const { Team, Group, Division, TeamsSession, Session, Season } = require("./../models");
 const { getSessionByDivisionAndSeasonId } = require("./session.controller");
 
 const TeamController = function () {
@@ -78,8 +77,15 @@ const TeamController = function () {
               id: session.division_id,
             },
           });
+          const season = await Season.findOne({
+            where: {
+              id: session.season_id,
+            }
+          })
           finalTeams[index].dataValues.division_name = division.name;
           finalTeams[index].dataValues.division_id = division.id;
+          finalTeams[index].dataValues.season_name = season.name;
+          finalTeams[index].dataValues.season_id = season.id;
         }),
       );
 


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Adds a column to the Teams page to display the season that they belong to. 

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally

### Additional Notes
