### PR TITLE
fix: get group id upon first registration to show leagues

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { I18nextProvider } from "react-i18next";
 import i18next from "./i18n/config";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { useRouter } from "./pages/Routes";
+import { GroupProvider } from "./components/GroupProvider/GroupProvider";
 
 const queryClient = new QueryClient();
 const router = useRouter();
@@ -11,7 +12,9 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <I18nextProvider i18n={i18next}>
-        <RouterProvider router={router} />
+        <GroupProvider>
+          <RouterProvider router={router} />
+        </GroupProvider>
       </I18nextProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -53,8 +53,6 @@ const TeamForm: React.FC<TeamFormProps> = ({
     uploadPhoto();
   }, [fileUrl]);
 
-  console.log("seasonsData", seasonsData);
-
   useEffect(() => {
     if (seasonId !== 0) {
       setLinkToSeason(true);

--- a/client/src/components/GroupProvider/GroupProvider.tsx
+++ b/client/src/components/GroupProvider/GroupProvider.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface GroupContextProps {
+  groupId: number;
+  setGroupId: (id: number) => void;
+}
+
+const GroupContext = createContext<GroupContextProps | undefined>(undefined);
+
+export const GroupProvider = ({ children }: { children: ReactNode }) => {
+  const [groupId, setGroupId] = useState<number>(0);
+
+  return (
+    <GroupContext.Provider value={{ groupId, setGroupId }}>
+      {children}
+    </GroupContext.Provider>
+  );
+};
+
+export const useGroup = () => {
+  const context = useContext(GroupContext);
+  if (!context) {
+    throw new Error("useGroup must be used within a GroupProvider");
+  }
+  return context;
+};

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -6,11 +6,19 @@ import { fetchUser } from "../../api/users/service";
 import Cookies from "js-cookie";
 import Navbar from "../../components/NavBar/NavBar";
 import Page from "../../components/Page/Page";
+import { useGroup } from "../../components/GroupProvider/GroupProvider";
 
 const Home = () => {
   const { isAuthenticated, user, getAccessTokenSilently } = useAuth0();
   const [registered, setRegistered] = useState<boolean | null>(null);
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false);
+  const { setGroupId } = useGroup();
+
+  // Function to handle registration completion
+  const handleRegistrationComplete = () => {
+    setRegistered(true);
+    setIsRegisterModalOpen(false);
+  };
 
   useEffect(() => {
     const checkRegistrationStatus = async () => {
@@ -21,6 +29,7 @@ const Home = () => {
           const response = await fetchUser(user.email || "", token);
           setRegistered(response?.isSigningUp ? false : true);
           Cookies.set("group_id", response?.group_id || 0);
+          setGroupId(response?.group_id);
         } catch (error) {
           console.error("Error checking registration status:", error);
           setRegistered(false);
@@ -31,7 +40,13 @@ const Home = () => {
     };
 
     checkRegistrationStatus();
-  }, [isAuthenticated, user, getAccessTokenSilently]);
+  }, [
+    isAuthenticated,
+    user,
+    getAccessTokenSilently,
+    registered,
+    handleRegistrationComplete,
+  ]);
 
   // Move the modal opening logic to a useEffect hook to avoid triggering re-renders
   useEffect(() => {
@@ -45,12 +60,6 @@ const Home = () => {
       setIsRegisterModalOpen(true);
     }
   }, [isRegisterModalOpen, registered]);
-
-  // Function to handle registration completion
-  const handleRegistrationComplete = () => {
-    setRegistered(true);
-    setIsRegisterModalOpen(false);
-  };
 
   if (registered === null) {
     return <></>;

--- a/client/src/pages/Leagues/Leagues.tsx
+++ b/client/src/pages/Leagues/Leagues.tsx
@@ -12,10 +12,8 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { getLeagueByGroupId } from "../../api/leagues/service";
 import { Outlet, useLocation } from "react-router-dom";
-import Cookies from "js-cookie";
-import { useAuth0 } from "@auth0/auth0-react";
-import { fetchUser } from "../../api/users/service";
 import { FaPlus } from "react-icons/fa";
+import { useGroup } from "../../components/GroupProvider/GroupProvider";
 
 const Leagues = () => {
   const { t } = useTranslation("Leagues");
@@ -26,24 +24,15 @@ const Leagues = () => {
   const [currentLeagueId, setCurrentLeagueId] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
+  const { groupId } = useGroup();
 
-  const { getAccessTokenSilently } = useAuth0();
-  const [groupId, setGroupId] = useState(0);
+  useEffect(() => {}, [groupId]);
 
   // const filterStatuses = [t("filterOptions.item1"), t("filterOptions.item2")];
   // const sortStatuses = [t("sortOptions.item1"), t("sortOptions.item2")];
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      const token = await getAccessTokenSilently();
-      const email = Cookies.get("email") || "";
-      const currentUser = await fetchUser(email, token);
-      setGroupId(currentUser.group_id);
-    })();
-  }, []);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["leagues", groupId ? groupId : 0],
@@ -73,7 +62,7 @@ const Leagues = () => {
   };
 
   const filteredData = data?.filter((league: LeagueType) =>
-    league.name.toLowerCase().includes(debouncedQuery.toLowerCase()),
+    league.name.toLowerCase().includes(debouncedQuery.toLowerCase())
   );
 
   const location = useLocation();


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
When users first log in should be able to render Leagues for current group selected immediately:

![Recording 2025-02-25 at 09 44 22](https://github.com/user-attachments/assets/9a697064-c89f-4c34-87c3-6fba05b2017c)

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
