### PR TITLE
fix: edit modals to show original data

### DIFF
--- a/client/src/components/Forms/DivisionForm/DivisionForm.tsx
+++ b/client/src/components/Forms/DivisionForm/DivisionForm.tsx
@@ -20,14 +20,15 @@ import { SeasonType } from "../../../pages/Seasons/types";
 const DivisionForm: React.FC<DivisionFormProps> = ({
   afterSave,
   divisionId,
+  division_name,
   requestType,
-  // seasonId,
+  season_id,
   seasonData,
 }) => {
   const { t } = useTranslation("Divisions");
-  const [divisionName, setDivisionName] = useState("");
+  const [divisionName, setDivisionName] = useState(division_name);
   const [isLoading, setIsLoading] = useState(false);
-  const [seasonId, setSeasonId] = useState(0);
+  const [seasonId, setSeasonId] = useState(season_id);
 
   const groupId = Cookies.get("group_id") || 0;
 

--- a/client/src/components/Forms/DivisionForm/types.ts
+++ b/client/src/components/Forms/DivisionForm/types.ts
@@ -5,7 +5,8 @@ interface DivisionFormProps {
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
   divisionId?: number;
-  seasonId?: number;
+  division_name?: string;
+  season_id?: number;
   seasonData?: SeasonType[];
 }
 

--- a/client/src/components/Forms/LeagueForm/LeagueForm.tsx
+++ b/client/src/components/Forms/LeagueForm/LeagueForm.tsx
@@ -23,10 +23,12 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
   afterSave,
   requestType,
   leagueId,
+  name,
+  description,
 }) => {
   const { t } = useTranslation("Leagues");
-  const [leagueName, setLeagueName] = useState("");
-  const [leagueDesc, setLeagueDesc] = useState("");
+  const [leagueName, setLeagueName] = useState(name);
+  const [leagueDesc, setLeagueDesc] = useState(description);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
 
   const { getAccessTokenSilently } = useAuth0();
@@ -47,7 +49,7 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const { leagueName, leagueDescription } = Object.fromEntries(
-      new FormData(event.currentTarget),
+      new FormData(event.currentTarget)
     );
 
     const data = {
@@ -86,7 +88,8 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
         <DeleteForm
           destructBtnLabel={t("formContent.delete")}
           onSubmit={handleSubmit}
-          className={styles.form}>
+          className={styles.form}
+        >
           <p>{t("formContent.deleteMessage")}</p>
         </DeleteForm>
       ) : (
@@ -130,7 +133,8 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
             <div>
               <button
                 type="submit"
-                className={`${styles.btn} ${styles.submitBtn}`}>
+                className={`${styles.btn} ${styles.submitBtn}`}
+              >
                 {requestType === "POST"
                   ? t("formContent.create")
                   : t("formContent.edit")}

--- a/client/src/components/Forms/LeagueForm/types.tsx
+++ b/client/src/components/Forms/LeagueForm/types.tsx
@@ -3,6 +3,8 @@ interface LeagueFormProps {
   afterSave: () => void | null;
   requestType?: "POST" | "PATCH" | "DELETE";
   leagueId?: number;
+  name?: string;
+  description?: string;
 }
 
 interface LeagueFormData {

--- a/client/src/components/Forms/SeasonForm/SeasonForm.tsx
+++ b/client/src/components/Forms/SeasonForm/SeasonForm.tsx
@@ -25,7 +25,6 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
   end,
   leagueData,
 }) => {
-  console.log("start: ", start, "end: ", end);
   const { t } = useTranslation("Seasons");
   const [leagueId, setLeagueId] = React.useState(league_id);
   const [seasonName, setSeasonName] = React.useState(name);
@@ -157,7 +156,7 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
                   endDate ? new Date(endDate).toISOString().split("T")[0] : ""
                 }
                 onChange={(event) =>
-                  setStartDate(new Date(event.target.value).toISOString())
+                  setEndDate(new Date(event.target.value).toISOString())
                 }
               />
             </div>

--- a/client/src/components/Forms/SeasonForm/SeasonForm.tsx
+++ b/client/src/components/Forms/SeasonForm/SeasonForm.tsx
@@ -19,13 +19,18 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
   afterSave,
   requestType,
   seasonId,
+  league_id,
+  name,
+  start,
+  end,
   leagueData,
 }) => {
+  console.log("start: ", start, "end: ", end);
   const { t } = useTranslation("Seasons");
-  const [leagueId, setLeagueId] = React.useState(0);
-  const [seasonName, setSeasonName] = React.useState("");
-  const [startDate, setStartDate] = React.useState("");
-  const [endDate, setEndDate] = React.useState("");
+  const [leagueId, setLeagueId] = React.useState(league_id);
+  const [seasonName, setSeasonName] = React.useState(name);
+  const [startDate, setStartDate] = React.useState(start);
+  const [endDate, setEndDate] = React.useState(end);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const createSeasonMutation = useCreateSeason();
@@ -128,8 +133,14 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
                 type="date"
                 id="startDate"
                 name="startDate"
-                value={startDate}
-                onChange={(event) => setStartDate(event.target.value)}
+                value={
+                  startDate
+                    ? new Date(startDate).toISOString().split("T")[0]
+                    : ""
+                }
+                onChange={(event) =>
+                  setStartDate(new Date(event.target.value).toISOString())
+                }
               />
             </div>
             <div className={styles.inputContainer}>
@@ -142,8 +153,12 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
                 type="date"
                 id="endDate"
                 name="endDate"
-                value={endDate}
-                onChange={(event) => setEndDate(event.target.value)}
+                value={
+                  endDate ? new Date(endDate).toISOString().split("T")[0] : ""
+                }
+                onChange={(event) =>
+                  setStartDate(new Date(event.target.value).toISOString())
+                }
               />
             </div>
           </div>

--- a/client/src/components/Forms/SeasonForm/types.tsx
+++ b/client/src/components/Forms/SeasonForm/types.tsx
@@ -5,6 +5,10 @@ interface SeasonFormProps {
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
   seasonId?: number;
+  league_id?: number;
+  name?: string;
+  start?: string;
+  end?: string;
   leagueData?: LeagueType[];
 }
 

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -23,15 +23,18 @@ import { uploadPhotoToS3 } from "../../../api/photo/service";
 const TeamForm: React.FC<TeamFormProps> = ({
   afterSave,
   requestType,
+  name,
+  season_id,
+  division_id,
   teamId,
   divisionsData,
   seasonsData,
 }) => {
   const { t } = useTranslation("Teams");
-  const [teamName, setTeamName] = useState("");
-  const [divisionId, setDivisionId] = useState(0);
-  const [seasonId, setSeasonId] = useState(0);
-  const [linkToSeason, setLinkToSeason] = useState(true);
+  const [teamName, setTeamName] = useState(name);
+  const [divisionId, setDivisionId] = useState(division_id);
+  const [seasonId, setSeasonId] = useState(season_id);
+  const [linkToSeason, setLinkToSeason] = useState(season_id !== undefined);
   const groupId = Number(Cookies.get("group_id")) || 0;
 
   const [fileUrl, setFileUrl] = useState<File | null>(null);
@@ -52,12 +55,6 @@ const TeamForm: React.FC<TeamFormProps> = ({
     };
     uploadPhoto();
   }, [fileUrl]);
-
-  useEffect(() => {
-    if (seasonId !== 0) {
-      setLinkToSeason(true);
-    }
-  }, [seasonId]);
 
   const createTeamMutation = useCreateTeam();
   const updateTeamMutation = useUpdateTeam();

--- a/client/src/components/Forms/TeamsForm/types.ts
+++ b/client/src/components/Forms/TeamsForm/types.ts
@@ -6,6 +6,9 @@ interface TeamFormProps {
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
   teamId?: number;
+  name?: string;
+  season_id?: number;
+  division_id?: number;
   divisionsData?: DivisionType[];
   seasonsData?: SeasonType[];
 }

--- a/client/src/pages/Division/Division.tsx
+++ b/client/src/pages/Division/Division.tsx
@@ -24,6 +24,7 @@ const Divisions = () => {
   // const [sorts, setSorts] = useState("");
   const [currentDivisionName, setCurrentDivisionName] = useState("");
   const [currentDivisionId, setCurrentDivisionId] = useState(0);
+  const [currentSeasonId, setCurrentSeasonId] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -75,9 +76,14 @@ const Divisions = () => {
   const isLoading = divisionsQuery.isLoading;
   const isError = divisionsQuery.isError;
 
-  const handleEdit = (divisionName: string, divisionId: number) => {
+  const handleEdit = (
+    divisionName: string,
+    divisionId: number,
+    seasonId: number
+  ) => {
     setCurrentDivisionName(divisionName);
     setCurrentDivisionId(divisionId);
+    setCurrentSeasonId(seasonId);
     setIsEditOpen(true);
   };
 
@@ -190,7 +196,13 @@ const Divisions = () => {
                   <td>
                     <DropdownMenuButton>
                       <DropdownMenuButton.Item
-                        onClick={() => handleEdit(division.name, division.id)}
+                        onClick={() =>
+                          handleEdit(
+                            division.name,
+                            division.id,
+                            division.season_id
+                          )
+                        }
                       >
                         {t("edit")}
                       </DropdownMenuButton.Item>
@@ -217,7 +229,9 @@ const Divisions = () => {
             <DivisionForm
               afterSave={() => setIsEditOpen(false)}
               requestType="PATCH"
+              division_name={currentDivisionName}
               divisionId={currentDivisionId}
+              season_id={currentSeasonId}
               seasonData={seasonsQuery.data}
             />
           </Modal.Content>

--- a/client/src/pages/Leagues/Leagues.tsx
+++ b/client/src/pages/Leagues/Leagues.tsx
@@ -21,6 +21,7 @@ const Leagues = () => {
   // const [filter, setFilter] = useState("");
   // const [sorts, setSorts] = useState("");
   const [currentLeagueName, setCurrentLeagueName] = useState("");
+  const [currentLeagueDescription, setCurrentLeagueDescription] = useState("");
   const [currentLeagueId, setCurrentLeagueId] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -49,9 +50,14 @@ const Leagues = () => {
     };
   }, [searchQuery]);
 
-  const handleEdit = (leagueName: string, leagueId: number) => {
+  const handleEdit = (
+    leagueName: string,
+    leagueId: number,
+    leagueDescription: string
+  ) => {
     setCurrentLeagueName(leagueName);
     setCurrentLeagueId(leagueId);
+    setCurrentLeagueDescription(leagueDescription);
     setIsEditOpen(true);
   };
 
@@ -122,7 +128,9 @@ const Leagues = () => {
                   <td className={styles.tableData}>
                     <DropdownMenuButton>
                       <DropdownMenuButton.Item
-                        onClick={() => handleEdit(league.name, league.id)}
+                        onClick={() =>
+                          handleEdit(league.name, league.id, league.description)
+                        }
                       >
                         {t("edit")}
                       </DropdownMenuButton.Item>
@@ -149,6 +157,8 @@ const Leagues = () => {
             <LeagueForm
               afterSave={() => setIsEditOpen(false)}
               requestType="PATCH"
+              name={currentLeagueName}
+              description={currentLeagueDescription}
               leagueId={currentLeagueId}
             />
           </Modal.Content>

--- a/client/src/pages/Seasons/Seasons.tsx
+++ b/client/src/pages/Seasons/Seasons.tsx
@@ -22,6 +22,9 @@ const Seasons = () => {
   const [sorts, setSorts] = useState("");
   const [currentSeasonName, setCurrentSeasonName] = useState("");
   const [currentSeasonId, setCurrentSeasonId] = useState(0);
+  const [currentLeagueId, setCurrentLeagueId] = useState(0);
+  const [currentStartDate, setCurrentStartDate] = useState("");
+  const [currentEndDate, setCurrentEndDate] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -78,13 +81,23 @@ const Seasons = () => {
       year: "numeric",
       month: "long",
       day: "numeric",
+      timeZone: "UTC",
     };
     return new Date(dateString).toLocaleDateString(undefined, options);
   };
 
-  const handleEdit = (seasonName: string, seasonId: number) => {
+  const handleEdit = (
+    seasonName: string,
+    seasonId: number,
+    leagueId: number,
+    startDate: string,
+    endDate: string
+  ) => {
     setCurrentSeasonName(seasonName);
     setCurrentSeasonId(seasonId);
+    setCurrentLeagueId(leagueId);
+    setCurrentStartDate(startDate);
+    setCurrentEndDate(endDate);
     setIsEditOpen(true);
   };
 
@@ -188,7 +201,15 @@ const Seasons = () => {
                   <td>
                     <DropdownMenuButton>
                       <DropdownMenuButton.Item
-                        onClick={() => handleEdit(season.name, season.id)}
+                        onClick={() =>
+                          handleEdit(
+                            season.name,
+                            season.id,
+                            season.league_id,
+                            season.start_date,
+                            season.end_date
+                          )
+                        }
                       >
                         {t("edit")}
                       </DropdownMenuButton.Item>
@@ -217,6 +238,10 @@ const Seasons = () => {
               requestType="PATCH"
               seasonId={currentSeasonId}
               leagueData={leaguesQuery.data}
+              name={currentSeasonName}
+              league_id={currentLeagueId}
+              start={currentStartDate}
+              end={currentEndDate}
             />
           </Modal.Content>
         </Modal>

--- a/client/src/pages/Teams/Teams.tsx
+++ b/client/src/pages/Teams/Teams.tsx
@@ -22,6 +22,8 @@ const Teams = () => {
   // const [sorts, setSorts] = useState("");
   const [currentTeamName, setCurrentTeamName] = useState("");
   const [currentTeamId, setCurrentTeamId] = useState(0);
+  const [currentDivisionId, setCurrentDivisionId] = useState(0);
+  const [currentSeasonId, setCurrentSeasonId] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -81,9 +83,16 @@ const Teams = () => {
     };
   }, [searchQuery]);
 
-  const handleEdit = (teamName: string, teamId: number) => {
+  const handleEdit = (
+    teamName: string,
+    teamId: number,
+    divisionId: number,
+    seasonId: number
+  ) => {
     setCurrentTeamName(teamName);
     setCurrentTeamId(teamId);
+    setCurrentDivisionId(divisionId);
+    setCurrentSeasonId(seasonId);
     setIsEditOpen(true);
   };
 
@@ -176,15 +185,22 @@ const Teams = () => {
                     </div>
                   </td>
                   <td>
-                    {team.season_name || <span>Not linked to a season</span>}
+                    {team.season_name || <span>Not linked to season</span>}
                   </td>
                   <td>
-                    {team.division_name || <span>Not linked to a division</span>}
+                    {team.division_name || <span>Not linked to season</span>}
                   </td>
                   <td>
                     <DropdownMenuButton>
                       <DropdownMenuButton.Item
-                        onClick={() => handleEdit(team.name, team.id)}
+                        onClick={() =>
+                          handleEdit(
+                            team.name,
+                            team.id,
+                            team.division_id,
+                            team.season_id
+                          )
+                        }
                       >
                         {t("edit")}
                       </DropdownMenuButton.Item>
@@ -213,6 +229,9 @@ const Teams = () => {
               requestType="PATCH"
               divisionsData={divisionsQuery.data}
               seasonsData={seasonsQuery.data}
+              name={currentTeamName}
+              division_id={currentDivisionId}
+              season_id={currentSeasonId}
               teamId={currentTeamId}
             />
           </Modal.Content>

--- a/server/controllers/division.controller.js
+++ b/server/controllers/division.controller.js
@@ -84,12 +84,6 @@ const DivisionController = {
 
     try {
       const division = await modelByPk(res, Division, id);
-      const isUnique = await isDivisionNameUnique(division.group_id, name);
-      if (!isUnique) {
-        res.status(400);
-        throw new Error("Division name already taken");
-      }
-
       division.name = name;
       await division.validate();
       await division.save();

--- a/server/controllers/league.controller.js
+++ b/server/controllers/league.controller.js
@@ -31,7 +31,7 @@ const LeagueController = function () {
       },
     });
 
-    return leagueFound == null;
+    return leagueFound === null;
   };
 
   var createLeague = async function (req, res, next) {
@@ -78,15 +78,6 @@ const LeagueController = function () {
             : currentLeague[key];
         }
       });
-
-      const leagueFound = await isNameUniqueWithinGroup(
-        currentLeague.group_id,
-        currentLeague.name,
-      );
-
-      if (!leagueFound) {
-        throw new Error("name is not unique");
-      }
 
       await currentLeague.validate();
       await currentLeague.save();

--- a/server/controllers/season.controller.js
+++ b/server/controllers/season.controller.js
@@ -200,13 +200,6 @@ const SeasonController = {
         }
       });
 
-      const { name, league_id } = season;
-      const isUnique = await isNameUniqueWithinLeague(name, league_id);
-      if (!isUnique) {
-        res.status(400);
-        throw new Error("name is not unique");
-      }
-
       await season.validate();
       await season.save();
       res.json(season);


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Show original values populated when in the edit modal. 
![Recording 2025-02-25 at 18 55 39](https://github.com/user-attachments/assets/26f0637d-a514-4126-a554-acab1a9efe4e)


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
