### PR TITLE
feat: capture payments modal in form responses

### DIFF
--- a/client/src/assets/Icons/AcceptIcon.tsx
+++ b/client/src/assets/Icons/AcceptIcon.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+export default function AcceptIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 48 48"
+      width={props.width}
+      height={props.height}
+      {...props}
+    >
+      <path
+        fill="#c8e6c9"
+        d="M44,24c0,11.045-8.955,20-20,20S4,35.045,4,24S12.955,4,24,4S44,12.955,44,24z"
+      />
+      <path
+        fill="#4caf50"
+        d="M34.586,14.586l-13.57,13.586l-5.602-5.586l-2.828,2.828l8.434,8.414l16.395-16.414L34.586,14.586z"
+      />
+    </svg>
+  );
+}

--- a/client/src/assets/Icons/RejectIcon.tsx
+++ b/client/src/assets/Icons/RejectIcon.tsx
@@ -1,0 +1,26 @@
+import { SVGProps } from "react";
+
+export default function RejectIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 48 48"
+      width={props.width}
+      height={props.height}
+      {...props}
+    >
+      <path
+        fill="#f44336"
+        d="M44,24c0,11.045-8.955,20-20,20S4,35.045,4,24S12.955,4,24,4S44,12.955,44,24z"
+      />
+      <path
+        fill="#fff"
+        d="M29.656,15.516l2.828,2.828l-14.14,14.14l-2.828-2.828L29.656,15.516z"
+      />
+      <path
+        fill="#fff"
+        d="M32.484,29.656l-2.828,2.828l-14.14-14.14l2.828-2.828L32.484,29.656z"
+      />
+    </svg>
+  );
+}

--- a/client/src/assets/Icons/index.tsx
+++ b/client/src/assets/Icons/index.tsx
@@ -8,6 +8,8 @@ import PlusCircleIcon from "./PlusCircleIcon";
 import TrashBinIcon from "./TrashBinIcon";
 import StripeConnectionIcon from "./StripeConnectIcon";
 import StripeLogoIcon from "./StripeLogoIcon";
+import AcceptIcon from "./AcceptIcon";
+import RejectIcon from "./RejectIcon";
 
 export {
   HomePageLogoIcon,
@@ -20,4 +22,6 @@ export {
   TrashBinIcon,
   StripeConnectionIcon,
   StripeLogoIcon,
+  AcceptIcon,
+  RejectIcon,
 };

--- a/client/src/components/Forms/Form.module.css
+++ b/client/src/components/Forms/Form.module.css
@@ -41,6 +41,16 @@
   color: black;
 }
 
+.subtitle {
+  padding-bottom: 25px;
+}
+
+.centered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .label {
   font-size: 1.1rem;
   color: black;
@@ -168,3 +178,23 @@
   width: 20px;
 }
 
+.acceptButton {
+  width: 100px;
+  height: 27px;
+  color: white;
+  background-color: #e9ffe8;
+  padding: 0%;
+  outline: 0px solid transparent;
+  border-radius: 21.5px;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+}
+.rejectButton {
+  width: 100px;
+  height: 27px;
+  color: white;
+  background-color: #ffeeee;
+  padding: 0%;
+  outline: 0px solid transparent;
+  border-radius: 21.5px;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+}

--- a/client/src/components/PaymentCapture/PaymentCapture.tsx
+++ b/client/src/components/PaymentCapture/PaymentCapture.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { Text } from "@radix-ui/themes";
+import { Answer } from "../../api/forms/types";
+import styles from "../Forms/Form.module.css";
+import Modal from "../Modal/Modal";
+import { AcceptIcon, RejectIcon } from "../../assets/Icons";
+
+interface PaymentCaptureModalProps {
+  amount: string;
+  status: string;
+  index: number;
+  response: Record<string, Answer>;
+  handleStatusChange: (
+    index: number,
+    statusUpdate: "approved" | "rejected" | "pending",
+    response: Record<string, Answer>
+  ) => void;
+}
+
+interface PaymentCaptureProps {
+  amount: string;
+}
+
+const REJECTED = "rejected";
+const APPROVED = "approved";
+
+interface CapturePaymentProps {
+  index: number;
+  response: Record<string, Answer>;
+  setCaptureStatus: React.Dispatch<React.SetStateAction<string>>;
+  handleStatusChange: (
+    index: number,
+    statusUpdate: "approved" | "rejected" | "pending",
+    response: Record<string, Answer>
+  ) => void;
+}
+
+const CapturePayment: React.FC<CapturePaymentProps> = ({
+  index,
+  response,
+  setCaptureStatus,
+  handleStatusChange,
+}) => {
+  return (
+    <div style={{ justifyContent: "center", alignItems: "center" }}>
+      <div className={styles.inputContainer}>
+        <Text className={styles.boldLabel}>
+          Are you sure you want to capture these payments
+        </Text>
+        <Text className={styles.subtitle}>
+          Note that these changes are not reversible.
+        </Text>
+      </div>
+      <div className={styles.formBtnContainer}>
+        <Modal.Close className={`${styles.btn} ${styles.cancelBtn}`}>
+          Cancel
+        </Modal.Close>
+
+        <button
+          className={`${styles.btn} ${styles.submitBtn}`}
+          onClick={() => {
+            setCaptureStatus(REJECTED);
+            handleStatusChange(index, REJECTED, response);
+          }}
+        >
+          Reject
+        </button>
+
+        <button
+          className={`${styles.btn} ${styles.submitBtn}`}
+          onClick={() => {
+            setCaptureStatus(APPROVED);
+            handleStatusChange(index, APPROVED, response);
+          }}
+        >
+          Approve
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const ApprovePaymentCapture: React.FC<PaymentCaptureProps> = ({ amount }) => {
+  return (
+    <div className={styles.centered}>
+      <AcceptIcon width={100} height={100} />
+      <Text>The payment of {amount} been approved and captured.</Text>
+    </div>
+  );
+};
+
+const RejectPaymentCapture: React.FC<PaymentCaptureProps> = ({ amount }) => {
+  return (
+    <div className={styles.centered}>
+      <RejectIcon width={100} height={100} />
+      <Text>The payment of {amount} has been rejected.</Text>
+    </div>
+  );
+};
+
+const PaymentCapture: React.FC<PaymentCaptureModalProps> = ({
+  amount,
+  status,
+  index,
+  response,
+  handleStatusChange,
+}) => {
+  const [page, setPage] = useState(0);
+  const [captureStatus, setCaptureStatus] = useState("pending");
+
+  // setting from the status being passed in
+  useEffect(() => {
+    if (status === APPROVED) {
+      setPage(1);
+    } else if (status === REJECTED) {
+      setPage(2);
+    }
+  }, [status]);
+
+  // setting when action has been taken
+  useEffect(() => {
+    if (captureStatus === APPROVED) {
+      setPage(1);
+    } else if (captureStatus === REJECTED) {
+      setPage(2);
+    }
+  }, [captureStatus]);
+
+  return (
+    <>
+      {page === 0 && (
+        <CapturePayment
+          index={index}
+          response={response}
+          setCaptureStatus={setCaptureStatus}
+          handleStatusChange={handleStatusChange}
+        />
+      )}
+      {page === 1 && <ApprovePaymentCapture amount={amount} />}
+      {page === 2 && <RejectPaymentCapture amount={amount} />}
+    </>
+  );
+};
+
+export default PaymentCapture;

--- a/client/src/components/StatusLabel/StatusLabel.module.css
+++ b/client/src/components/StatusLabel/StatusLabel.module.css
@@ -1,6 +1,9 @@
 .statusLabel {
   width: fit-content;
   font-size: 0.925rem;
-  padding: 1px 16px;
+  padding: 1px 10px;
   border-radius: 30px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }

--- a/client/src/components/StatusLabel/StatusLabel.tsx
+++ b/client/src/components/StatusLabel/StatusLabel.tsx
@@ -1,8 +1,10 @@
 import styles from "./StatusLabel.module.css";
+import { IoMdArrowDropdown } from "react-icons/io";
 
 export interface StatusLabelProps {
   status: "approved" | "rejected" | "pending";
   children: React.ReactNode;
+  renderDropdown?: boolean;
 }
 
 const statusLabelStyling = (status: string) => {
@@ -22,10 +24,15 @@ const statusLabelStyling = (status: string) => {
   };
 };
 
-const StatusLabel: React.FC<StatusLabelProps> = ({ status, children }) => {
+const StatusLabel: React.FC<StatusLabelProps> = ({
+  status,
+  children,
+  renderDropdown = false,
+}) => {
   return (
     <p style={statusLabelStyling(status)} className={styles.statusLabel}>
       {children}
+      {renderDropdown && <IoMdArrowDropdown />}
     </p>
   );
 };


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Working to include modal experience when capturing payments. After the action is done, it can not be undone and the success or failure will always show as suggested.

#### Capture Payment Flow
![Recording 2025-02-26 at 23 30 29](https://github.com/user-attachments/assets/3b6b4852-e045-4217-9e8f-0755f3f2e94a)

#### Reject Payment Flow
![Recording 2025-02-26 at 23 31 21](https://github.com/user-attachments/assets/0cefc975-7d38-42b0-a96e-041c0618943b)


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
Dropdown icon near status label: https://cascarita.atlassian.net/browse/CV-93
confirmation before and after payment capture: https://cascarita.atlassian.net/browse/CV-87

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
