### PR TITLE
feat: adding new form created confirmation modal

### DIFF
--- a/client/src/pages/NewForm/NewForm.module.css
+++ b/client/src/pages/NewForm/NewForm.module.css
@@ -42,7 +42,7 @@ h4 {
   max-height: 90%;
   scrollbar-width: thin;
   position: relative;
-  z-index: 10;
+  z-index: 1;
 }
 
 .formTitleContainer {

--- a/client/src/pages/NewForm/NewForm.tsx
+++ b/client/src/pages/NewForm/NewForm.tsx
@@ -15,6 +15,40 @@ import { User } from "../../api/users/types";
 import { Field, FieldType, Form } from "../../api/forms/types";
 import Cookies from "js-cookie";
 import { fetchUser } from "../../api/users/service";
+import BlueCheckMarkIcon from "../../assets/Icons/BlueCheckMarkIcon";
+import { Text } from "@radix-ui/themes";
+import Modal from "../../components/Modal/Modal";
+
+interface CreateFormConfirmationModalProps {
+  openModal: boolean;
+  setOpenModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+const CreateFormConfirmationModal: React.FC<
+  CreateFormConfirmationModalProps
+> = ({ openModal, setOpenModal }) => {
+  return (
+    <Modal open={openModal} onOpenChange={setOpenModal}>
+      <Modal.Content>
+        <div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              flexDirection: "column",
+              gap: "10px",
+              height: "100%",
+            }}
+          >
+            <BlueCheckMarkIcon />
+            <Text style={{ fontWeight: "bold" }}>Completed </Text>
+            <Text>You have successfully created a new form.</Text>
+          </div>
+        </div>
+      </Modal.Content>
+    </Modal>
+  );
+};
 
 const NewForm = () => {
   const { t } = useTranslation("NewForms");
@@ -22,6 +56,7 @@ const NewForm = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [fields, setFields] = useState<Field[]>(location.state?.fields ?? []);
+  const [openModal, setOpenModal] = useState(false);
   const [formId, setFormId] = useState<string | null>(
     (location.state?.id as string) ?? null
   );
@@ -110,6 +145,7 @@ const NewForm = () => {
     setFormLink(`${window.location.origin}/forms/${response._id}`);
     setFormId(response._id);
     setFields(response.form_data.fields);
+    setOpenModal(true);
   };
 
   // TODO: save by mongo form ID
@@ -227,10 +263,14 @@ const NewForm = () => {
                 items={droppedItems}
                 handleDelete={handleDelete}
                 handleCopy={handleCopy}
-                saveForm={formId == null ? onCreate : onSave}
+                saveForm={formId === null ? onCreate : onSave}
               />
             </div>
           </div>
+          <CreateFormConfirmationModal
+            openModal={openModal}
+            setOpenModal={setOpenModal}
+          />
         </div>
       )}
       {formId != null && activeSection === "responses" && (

--- a/client/src/pages/NewForm/NewForm.tsx
+++ b/client/src/pages/NewForm/NewForm.tsx
@@ -29,21 +29,19 @@ const CreateFormConfirmationModal: React.FC<
   return (
     <Modal open={openModal} onOpenChange={setOpenModal}>
       <Modal.Content>
-        <div>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              flexDirection: "column",
-              gap: "10px",
-              height: "100%",
-            }}
-          >
-            <BlueCheckMarkIcon />
-            <Text style={{ fontWeight: "bold" }}>Completed </Text>
-            <Text>You have successfully created a new form.</Text>
-          </div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            flexDirection: "column",
+            gap: "10px",
+            height: "100%",
+          }}
+        >
+          <BlueCheckMarkIcon />
+          <Text style={{ fontWeight: "bold" }}>Completed </Text>
+          <Text>You have successfully created a new form.</Text>
         </div>
       </Modal.Content>
     </Modal>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Adding modal when new form is created to help users understand that a new form has been created

https://github.com/user-attachments/assets/12ee1d1d-d675-411f-9339-4d185b7f1e60


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
https://cascarita.atlassian.net/browse/CV-92

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
