### PR TITLE
feat: adding who collects fee payment in registration form template modal

### DIFF
--- a/client/src/components/Forms/RegistrationTemplateForm/RegistrationTemplateForm.tsx
+++ b/client/src/components/Forms/RegistrationTemplateForm/RegistrationTemplateForm.tsx
@@ -40,7 +40,8 @@ const createRegistrationFormData = (
   price: number,
   feeValue: number,
   stripeUser: string,
-  stripeAccountId: string
+  stripeAccountId: string,
+  paymentFeeRecipient: string
 ): Form => {
   const first_name_id = uuidv4();
   const last_name_id = uuidv4();
@@ -184,7 +185,7 @@ const createRegistrationFormData = (
           value: price.toString(),
           feeValue: feeValue.toString(),
           currency: Currency.USD,
-          isCustomerPayingFee: false,
+          isCustomerPayingFee: paymentFeeRecipient === "customer",
         },
         stripe_account: { id: stripeUser, stripe_account_id: stripeAccountId },
         description: "",
@@ -245,6 +246,7 @@ const FormTemplateForm: React.FC<RegistrationTemplateFormProps> = ({
   const [stripeAccountId, setStripeAccountId] = useState("");
   const [stripeUser, setStripeUser] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
+  const [paymentFeeRecipient, setPaymentFeeRecipient] = useState("org");
   const description = "Please fill out all details for the registration form!";
 
   const navigate = useNavigate();
@@ -363,7 +365,8 @@ const FormTemplateForm: React.FC<RegistrationTemplateFormProps> = ({
         price,
         feeValue,
         stripeUser,
-        stripeAccountId
+        stripeAccountId,
+        paymentFeeRecipient
       );
       const token = await getAccessTokenSilently();
       const currentUser = await fetchUser(email, token);
@@ -553,6 +556,24 @@ const FormTemplateForm: React.FC<RegistrationTemplateFormProps> = ({
                 readOnly
               />
             </div>
+          </div>
+          <div className={styles.inputContainer}>
+            <label className={styles.label} htmlFor="isCustomerPayingFee">
+              Who will pay the processing fee?
+            </label>
+            <select
+              className={styles.input}
+              name="isCustomerPayingFee"
+              id="isCustomerPayingFee"
+              onChange={(e) => {
+                setPaymentFeeRecipient(e.target.value);
+              }}
+              required
+            >
+              <option value="">Select Option</option>
+              <option value="org">Organization</option>
+              <option value="customer">Customer</option>
+            </select>
           </div>
         </>
       )}


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Adding an option in the registration modal to select who will collect the payment fee

![Recording 2025-02-27 at 22 06 24](https://github.com/user-attachments/assets/a0906d29-1ac3-4d7e-b4ab-141f1859f6ac)

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
