### PR TITLE
adds api endpoint to return data needed for user settings' page

### DIFF
--- a/client/src/api/users/query.ts
+++ b/client/src/api/users/query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCompleteUserSettings, getUser } from "./service";
+
+export const useGetCompleteUserSettings = (userId: number) => {
+  return useQuery({
+    queryKey: ["stripe_accounts", userId],
+    queryFn: getCompleteUserSettings,
+    enabled: userId !== 0,
+  });
+};
+
+export const useFetchUser = (email: string, token: string) => {
+  return useQuery({
+    queryKey: ["user", email, token],
+    queryFn: getUser,
+  });
+};

--- a/client/src/api/users/query.ts
+++ b/client/src/api/users/query.ts
@@ -1,17 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { getCompleteUserSettings, getUser } from "./service";
 
-export const useGetCompleteUserSettings = (userId: number) => {
-  return useQuery({
-    queryKey: ["stripe_accounts", userId],
-    queryFn: getCompleteUserSettings,
-    enabled: userId !== 0,
-  });
-};
-
 export const useFetchUser = (email: string, token: string) => {
   return useQuery({
     queryKey: ["user", email, token],
     queryFn: getUser,
+  });
+};
+
+export const useGetCompleteUserSettings = (userId: number) => {
+  return useQuery({
+    queryKey: ["user_settings", userId ? userId : 0],
+    queryFn: getCompleteUserSettings,
+    enabled: userId !== 0,
   });
 };

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -11,6 +11,7 @@ import {
   LanguageCodeToLanguageId,
   RegisterUser,
   UserSettings,
+  UserSettingsResponse,
 } from "./types";
 import { User } from "./types";
 
@@ -262,7 +263,7 @@ const getSession = async (data: GetSessionData) => {
 
 const getCompleteUserSettings = async ({
   queryKey,
-}: QueryFunctionContext<UserSettingsQueryKey>): Promise<UserSettings> => {
+}: QueryFunctionContext<UserSettingsQueryKey>): Promise<UserSettingsResponse> => {
   const [, user_id] = queryKey;
   try {
     const response = await fetch(`/api/users/settings/${user_id}`, {
@@ -272,7 +273,7 @@ const getCompleteUserSettings = async ({
       },
     });
     const result = await response.json();
-    return result;
+    return result.userSettings;
   } catch (error) {
     console.error("Error fetching users:", error);
     throw error;

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -8,6 +8,8 @@ import {
 } from "../../components/Forms/UserForm/types";
 import { UserResponse, LanguageCodeToLanguageId, RegisterUser } from "./types";
 
+type UserSettingsQueryKey = [string, number];
+
 const updateUsersLanguages = async (
   user_id: number,
   language: string
@@ -219,6 +221,25 @@ const getSession = async (data: GetSessionData) => {
   }
 };
 
+const getCompleteUserSettings = async ({
+  queryKey,
+}: QueryFunctionContext<UserSettingsQueryKey>) => {
+  const [, user_id] = queryKey;
+  try {
+    const response = await fetch(`/api/users/settings/${user_id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Error fetching users:", error);
+    throw error;
+  }
+};
+
 export {
   updateUsersLanguages,
   registerUser,
@@ -230,4 +251,5 @@ export {
   updatePlayerTeams,
   getPlayersByGroupId,
   getSession,
+  getCompleteUserSettings,
 };

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -6,13 +6,19 @@ import {
   UpdatePlayerTeamsData,
   AddUserData,
 } from "../../components/Forms/UserForm/types";
-import { UserResponse, LanguageCodeToLanguageId, RegisterUser } from "./types";
+import {
+  UserResponse,
+  LanguageCodeToLanguageId,
+  RegisterUser,
+  UserSettings,
+} from "./types";
+import { User } from "./types";
 
-type UserSettingsQueryKey = [string, number];
+type UserSettingsQueryKey = [string, number | undefined];
 
 const updateUsersLanguages = async (
   user_id: number,
-  language: string
+  language: string,
 ): Promise<UserResponse> => {
   const language_id = LanguageCodeToLanguageId[language as "en" | "esp"];
 
@@ -156,6 +162,39 @@ const deleteUser = async (data: DeleteUserData): Promise<void> => {
   }
 };
 
+type GetUserQueryKey = [string, string, string];
+
+const getUser = async ({
+  queryKey,
+}: QueryFunctionContext<GetUserQueryKey>): Promise<User> => {
+  const [, email, token] = queryKey;
+
+  try {
+    // Encode the email to ensure it's safe for use in a URL
+    const response = await fetch(
+      `/api/users?email=${encodeURIComponent(email)}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    // Check if the response is OK (status in the range 200-299)
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Error fetching user:", error);
+    throw error;
+  }
+};
+
 const fetchUser = async (email: string, token: string) => {
   try {
     // Encode the email to ensure it's safe for use in a URL
@@ -167,7 +206,7 @@ const fetchUser = async (email: string, token: string) => {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-      }
+      },
     );
 
     // Check if the response is OK (status in the range 200-299)
@@ -184,7 +223,7 @@ const fetchUser = async (email: string, token: string) => {
 };
 
 const updatePlayerTeams = async (
-  data: UpdatePlayerTeamsData
+  data: UpdatePlayerTeamsData,
 ): Promise<UserResponse> => {
   try {
     const response = await fetch(`/api/users/${data.id}/players/teams`, {
@@ -223,7 +262,7 @@ const getSession = async (data: GetSessionData) => {
 
 const getCompleteUserSettings = async ({
   queryKey,
-}: QueryFunctionContext<UserSettingsQueryKey>) => {
+}: QueryFunctionContext<UserSettingsQueryKey>): Promise<UserSettings> => {
   const [, user_id] = queryKey;
   try {
     const response = await fetch(`/api/users/settings/${user_id}`, {
@@ -252,4 +291,5 @@ export {
   getPlayersByGroupId,
   getSession,
   getCompleteUserSettings,
+  getUser,
 };

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -10,7 +10,6 @@ import {
   UserResponse,
   LanguageCodeToLanguageId,
   RegisterUser,
-  UserSettings,
   UserSettingsResponse,
 } from "./types";
 import { User } from "./types";

--- a/client/src/api/users/types.ts
+++ b/client/src/api/users/types.ts
@@ -21,16 +21,6 @@ export interface User {
   language_id: number;
 }
 
-export interface UserSettings {
-  first_name: string;
-  last_name: string;
-  email: string;
-  user_picture: string;
-  group_name: string;
-  group_code: string;
-  group_logo: string;
-}
-
 export interface UserSettingsResponse {
   first_name: string;
   last_name: string;
@@ -39,6 +29,7 @@ export interface UserSettingsResponse {
   group_name: string;
   group_code: string;
   group_logo: string;
+  role: string;
 }
 
 export interface RegisterUser {

--- a/client/src/api/users/types.ts
+++ b/client/src/api/users/types.ts
@@ -21,6 +21,16 @@ export interface User {
   language_id: number;
 }
 
+export interface UserSettings {
+  first_name: string;
+  last_name: string;
+  email: string;
+  user_picture: string;
+  group_name: string;
+  group_code: string;
+  group_logo: string;
+}
+
 export interface RegisterUser {
   group_id: string | number | null; // they might be joining an existing group
   first_name: string | null;

--- a/client/src/api/users/types.ts
+++ b/client/src/api/users/types.ts
@@ -31,6 +31,16 @@ export interface UserSettings {
   group_logo: string;
 }
 
+export interface UserSettingsResponse {
+  first_name: string;
+  last_name: string;
+  email: string;
+  user_picture: string;
+  group_name: string;
+  group_code: string;
+  group_logo: string;
+}
+
 export interface RegisterUser {
   group_id: string | number | null; // they might be joining an existing group
   first_name: string | null;

--- a/client/src/components/Modal/Modal.module.css
+++ b/client/src/components/Modal/Modal.module.css
@@ -167,7 +167,7 @@
     transform: translate(-50%, -50%);
     width: 90vw;
     max-width: 650px;
-    max-height: 85vh;
+    max-height: 90vh;
     min-height: 0;
   }
   .content[data-state="open"] {

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -7,7 +7,6 @@ const Navbar: React.FC<NavbarProps> & {
   Item: React.FC<NavbarItemProps>;
 } = ({ children, className = "" }) => {
   const navbarClassName = `${styles.navbar} ${className}`;
-
   return (
     <nav id="navbar">
       <ul className={navbarClassName}>{children}</ul>
@@ -23,16 +22,20 @@ const NavbarItem: React.FC<NavbarItemProps> = ({
 }) => {
   const navbarItemClassName = `${styles.navbarLink} ${className}`;
 
-  const activeClass = (isActive: boolean) => {
-    [isActive ? `${styles.navbarLinkActive}` : ""].join(" ");
+  const activeClass = ({ isActive }: { isActive: boolean }) => {
+    return isActive
+      ? `${navbarItemClassName} ${styles.navbarLinkActive}`
+      : navbarItemClassName;
   };
 
   return (
     <li className={styles.navbarItem}>
       <NavLink
-        className={`${navbarItemClassName} ${activeClass}`}
+        className={activeClass}
         to={href}
-        {...delegated}>
+        end // Add the "end" prop to match exactly this path
+        {...delegated}
+      >
         {children}
       </NavLink>
     </li>
@@ -40,5 +43,4 @@ const NavbarItem: React.FC<NavbarItemProps> = ({
 };
 
 Navbar.Item = NavbarItem;
-
 export default Navbar;

--- a/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
+++ b/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
@@ -1,10 +1,7 @@
 import styles from "../Settings.module.css";
 import { Avatar } from "@radix-ui/themes";
 import { FaUser } from "react-icons/fa";
-import {
-  useFetchUser,
-  useGetCompleteUserSettings,
-} from "../../../api/users/query";
+import { useGetCompleteUserSettings } from "../../../api/users/query";
 import { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import Cookies from "js-cookie";
@@ -27,14 +24,8 @@ const AccountInfo = () => {
   }, []);
 
   const userId = currentUser?.id;
-  console.log(userId);
-  const { data: userSettings } = useGetCompleteUserSettings(
-    userId ? userId : 0,
-  );
-
-  console.log("User Settings: " + userSettings);
-  const userFullName = `${userSettings?.first_name} ${userSettings?.last_name}`;
-  console.log("User Full Name: " + userFullName);
+  const { data: user } = useGetCompleteUserSettings(userId ? userId : 0);
+  const userFullName = `${user?.first_name} ${user?.last_name}`;
 
   return (
     <section className={styles.settingsWrapper}>
@@ -44,14 +35,10 @@ const AccountInfo = () => {
           <p>Cascarita Account Information</p>
         </div>
         <Avatar
-          src={userSettings && userSettings.user_picture}
+          src={user && user.user_picture}
           fallback={
             <div className={styles.avatarFallback}>
-              {userSettings && userFullName ? (
-                getInitials(userFullName)
-              ) : (
-                <FaUser />
-              )}
+              {user && userFullName ? getInitials(userFullName) : <FaUser />}
             </div>
           }
           size={"7"}
@@ -63,12 +50,12 @@ const AccountInfo = () => {
       <div className={styles.accountTable}>
         <div className={styles.accountTableRow}>
           <h3>Full Name</h3>
-          <p>{userSettings && userFullName}</p>
+          <p>{user && userFullName}</p>
         </div>
 
         <div className={styles.accountTableRow}>
           <h3>Email</h3>
-          <p>{userSettings && userSettings.email}</p>
+          <p>{user && user.email}</p>
         </div>
 
         <div className={styles.accountTableRow}>

--- a/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
+++ b/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
@@ -1,8 +1,8 @@
 import styles from "../Settings.module.css";
 import { Avatar } from "@radix-ui/themes";
-import { FaUser } from "react-icons/fa";
+import { FaCopy, FaUser } from "react-icons/fa";
 import { useGetCompleteUserSettings } from "../../../api/users/query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import Cookies from "js-cookie";
 import { User } from "../../Users/types";
@@ -11,8 +11,26 @@ import { fetchUser } from "../../../api/users/service";
 const AccountInfo = () => {
   // State variables
   const [currentUser, setCurrentUser] = useState<User | null>(null);
-
   const { getAccessTokenSilently } = useAuth0();
+  const textBoxRef = useRef<HTMLInputElement>(null);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const handleCopy = () => {
+    if (textBoxRef.current) {
+      const text = textBoxRef.current.innerText;
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          setCopied(true);
+          setTimeout(() => {
+            setCopied(false);
+          }, 5000);
+        })
+        .catch((err) => {
+          console.error("Failed to copy text: ", err);
+        });
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -33,6 +51,23 @@ const AccountInfo = () => {
         <div className={styles.sectionTitleWrapper}>
           <h2>Your Profile</h2>
           <p>Cascarita Account Information</p>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <h3>Group Code</h3>
+            <div className={styles.shareContainer}></div>
+            {copied ? (
+              <p className={styles.copiedMessage}>Copied to clipboard!</p>
+            ) : (
+              <p className={styles.groupCodeText} ref={textBoxRef}>
+                {user?.group_code}
+              </p>
+            )}
+            <button
+              className={`${styles.btn} ${styles.copyBtn}`}
+              onClick={handleCopy}
+            >
+              <FaCopy style={{ height: "16px", width: "16px" }} />
+            </button>
+          </div>
         </div>
         <Avatar
           src={user && user.user_picture}
@@ -60,8 +95,9 @@ const AccountInfo = () => {
 
         <div className={styles.accountTableRow}>
           <h3>Role</h3>
-          <p>{currentUser?.role_id}</p>
+          <p>{user?.role}</p>
         </div>
+        <div className={styles.accountTableRow}></div>
       </div>
     </section>
   );

--- a/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
+++ b/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
@@ -1,10 +1,41 @@
 import styles from "../Settings.module.css";
 import { Avatar } from "@radix-ui/themes";
-import { useAuth0 } from "@auth0/auth0-react";
 import { FaUser } from "react-icons/fa";
+import {
+  useFetchUser,
+  useGetCompleteUserSettings,
+} from "../../../api/users/query";
+import { useEffect, useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import Cookies from "js-cookie";
+import { User } from "../../Users/types";
+import { fetchUser } from "../../../api/users/service";
 
 const AccountInfo = () => {
-  const { user } = useAuth0();
+  // State variables
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+
+  const { getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    (async () => {
+      const token = await getAccessTokenSilently();
+      const email = Cookies.get("email") || "";
+      const currentUser = await fetchUser(email, token);
+      setCurrentUser(currentUser);
+    })();
+  }, []);
+
+  const userId = currentUser?.id;
+  console.log(userId);
+  const { data: userSettings } = useGetCompleteUserSettings(
+    userId ? userId : 0,
+  );
+
+  console.log("User Settings: " + userSettings);
+  const userFullName = `${userSettings?.first_name} ${userSettings?.last_name}`;
+  console.log("User Full Name: " + userFullName);
+
   return (
     <section className={styles.settingsWrapper}>
       <div className={styles.sectionHeader}>
@@ -13,10 +44,14 @@ const AccountInfo = () => {
           <p>Cascarita Account Information</p>
         </div>
         <Avatar
-          src={user && user.picture}
+          src={userSettings && userSettings.user_picture}
           fallback={
             <div className={styles.avatarFallback}>
-              {user && user.name ? getInitials(user.name) : <FaUser />}
+              {userSettings && userFullName ? (
+                getInitials(userFullName)
+              ) : (
+                <FaUser />
+              )}
             </div>
           }
           size={"7"}
@@ -28,19 +63,17 @@ const AccountInfo = () => {
       <div className={styles.accountTable}>
         <div className={styles.accountTableRow}>
           <h3>Full Name</h3>
-          {/* <p>John</p> */}
-          <p>{user && user.name}</p>
+          <p>{userSettings && userFullName}</p>
         </div>
 
         <div className={styles.accountTableRow}>
           <h3>Email</h3>
-          <p>{user && user.email}</p>
+          <p>{userSettings && userSettings.email}</p>
         </div>
 
         <div className={styles.accountTableRow}>
           <h3>Role</h3>
-          {/* TODO: Add role info from Auth0  */}
-          <p>Player</p>
+          <p>{currentUser?.role_id}</p>
         </div>
       </div>
     </section>

--- a/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
+++ b/client/src/pages/Settings/AccountInfo/AccountInfo.tsx
@@ -51,23 +51,25 @@ const AccountInfo = () => {
         <div className={styles.sectionTitleWrapper}>
           <h2>Your Profile</h2>
           <p>Cascarita Account Information</p>
-          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-            <h3>Group Code</h3>
-            <div className={styles.shareContainer}></div>
-            {copied ? (
-              <p className={styles.copiedMessage}>Copied to clipboard!</p>
-            ) : (
-              <p className={styles.groupCodeText} ref={textBoxRef}>
-                {user?.group_code}
-              </p>
-            )}
-            <button
-              className={`${styles.btn} ${styles.copyBtn}`}
-              onClick={handleCopy}
-            >
-              <FaCopy style={{ height: "16px", width: "16px" }} />
-            </button>
-          </div>
+          {user?.role === "Admin" && (
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <h3>Group Code</h3>
+              <div className={styles.shareContainer}></div>
+              {copied ? (
+                <p className={styles.copiedMessage}>Copied to clipboard!</p>
+              ) : (
+                <p className={styles.groupCodeText} ref={textBoxRef}>
+                  {user?.group_code}
+                </p>
+              )}
+              <button
+                className={`${styles.btn} ${styles.copyBtn}`}
+                onClick={handleCopy}
+              >
+                <FaCopy style={{ height: "16px", width: "16px" }} />
+              </button>
+            </div>
+          )}
         </div>
         <Avatar
           src={user && user.user_picture}

--- a/client/src/pages/Settings/Settings.module.css
+++ b/client/src/pages/Settings/Settings.module.css
@@ -42,11 +42,12 @@
 .accountTable {
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: repeat(auto-fill, 80px);
+  grid-template-rows: repeat(4, 80px);
 }
 
 .accountTableRow {
   display: grid;
+  gap: 8px;
   grid-template-columns: 2fr 5fr;
   align-items: center;
   border-top: 1px solid #dfe5ee;
@@ -79,6 +80,39 @@
   border-radius: 50%;
 }
 
+.shareContainer {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.copiedMessage {
+  color: darkgreen;
+  font-weight: 500;
+}
+
+.groupCodeText {
+  padding: 8px 16px;
+  background-color: lightgrey;
+  border-radius: 8px;
+  color: gray;
+}
+
+.btn {
+  border-radius: 21.5px;
+  padding: 13px 45px;
+  outline: 1px solid #170cb4;
+  background-color: #170cb4;
+  color: #ffffff;
+}
+
+.copyBtn {
+  background-color: #4238d5;
+  color: #fff;
+  border-radius: 8px;
+  padding: 10px 16px;
+}
+
 .logoutBtn {
   display: flex;
   align-items: center;
@@ -90,7 +124,7 @@
     display: flex;
     flex-direction: column;
     align-items: start;
-    gap: 4px;
+    gap: 6px;
   }
 
   .sectionHeader {
@@ -135,6 +169,7 @@
 
   .accountTableRow {
     display: grid;
+    gap: 8px;
     grid-template-columns: 3fr 5fr;
     align-items: center;
     border-top: 1px solid #dfe5ee;

--- a/server/app.js
+++ b/server/app.js
@@ -50,9 +50,6 @@ app.use(
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-// Error handler should be the last middleware used
-app.use(Middlewares.errorHandler);
-
 const DivisionController = require("./routes/division.routes")(checkJwt);
 const FieldRoutes = require("./routes/field.routes")(checkJwt);
 const GroupRoutes = require("./routes/group.routes")(checkJwt);
@@ -81,6 +78,9 @@ app.use("/api/forms", FormRoutes);
 app.use("/api/accounts", AccountRoutes);
 app.use("/api/email", EmailRoutes);
 app.use("/api/images", S3Routes);
+
+// Error handler should be the last middleware used
+app.use(Middlewares.errorHandler);
 
 http.createServer(app).listen(app.get("port"), function () {
   console.log("Express server listening on port " + app.get("port"));

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -654,7 +654,6 @@ const UserController = function () {
         },
       });
 
-      console.log("UserRole", UserRole);
       if (!UserRole) {
         res.status(404).json({
           error: `no user role was found with user id ${user.id}`

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -32,6 +32,7 @@ const {
   TeamsSession,
   Season,
   Team,
+  Group,
 } = require("../models");
 const Db = require("../models");
 const GroupController = require("./group.controller");
@@ -629,6 +630,59 @@ const UserController = function () {
     });
   };
 
+  var getUserSettingsById = async function (req, res, next) {
+    try {
+      const { id } = req.params;
+
+      if (isNaN(id)) {
+        res.status(400).json({ error: "user id must be an integer" });
+      }
+
+      const user = await User.findByPk(id);
+      if (!user) {
+        res.status(404).json({ error: `no user was found with id ${id}` });
+      }
+
+      const group = await Group.findByPk(user.group_id);
+      if (!group) {
+        res.status(404).json({ error: `no group was found with id ${user.group_id}` });
+      }
+
+      const UserRole = await UserRoles.findOne({
+        where: {
+          user_id: user.id,
+        },
+      });
+
+      console.log("UserRole", UserRole);
+      if (!UserRole) {
+        res.status(404).json({
+          error: `no user role was found with user id ${user.id}`
+        });
+      }
+
+      let groupCode = group.group_code;
+      // Only admins and Staff are allowed to see the group code
+      if (UserRole.role_id >= 3) {
+        groupCode = "";
+      }
+
+      const userSettings = {
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email: user.email,
+        user_picture: user.picture,
+        group_name: group.name,
+        group_code: groupCode,
+        group_logo: group.logo_url,
+      };
+
+      return res.json({ userSettings });
+    } catch (error) {
+      next(error);
+    }
+  }
+
   return {
     registerUser,
     logInUser,
@@ -643,6 +697,7 @@ const UserController = function () {
     updatePlayerTeams,
     getSession,
     createUserViaFromResponse,
+    getUserSettingsById,
   };
 };
 

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -20,7 +20,9 @@ module.exports = (checkJwt) => {
   router.delete("/:id", UserController.deleteUserById);
   router.patch("/:id", UserController.updateUserById);
   router.post("/", UserController.addUser);
+  router.get("/settings/:id", UserController.getUserSettingsById);
   router.get("/roles/:id", UserRolesController.getUserRolesByUserId);
   router.patch("/roles/:id", UserRolesController.updateUserRole);
+
   return router;
 };


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
This PR is for the User's Settings page. It includes:
- API endpoint to that returns User and User's Group info
- Front end changes to display the Group code
- Fixes a bug where the NavBar loses its active styling when the user clicks away

### Issue Link
Part of [CV-60](https://cascarita.atlassian.net/browse/CV-60)
<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Screenshots

https://github.com/user-attachments/assets/daad4086-d5c0-40e6-a522-bada8392eda0


### Additional Notes
- The group code will only be displayed for Staff or Admin Roles. (Subject to change in the future)
- Middleware placement was also updated to catch unhandled errors.
- If a user is not an Admin or Staff, then no Settings information is displayed. Should we populate info from auth0 if they are not admin?
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/8755373d-da42-4aac-83c7-3f4c233b837e" />
