### PR TITLE
fix: accept/reject status button for specific indexes

### DIFF
--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -89,6 +89,7 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
     []
   );
   const [openModal, setOpenModal] = useState(false);
+  const [paymentCaptureIndex, setPaymentCaptureIndex] = useState(0);
   const adminEmail = Cookies.get("email") || "";
   const [formDocumentId, setFormDocumentId] = useState("");
   console.log(formDocumentId);
@@ -213,9 +214,9 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
     if (statusUpdate === "pending") {
       updatedStatus = "requires_payment_method";
     } else if (statusUpdate === "approved") {
-      updatedStatus = "approved";
+      updatedStatus = "succeeded";
     } else {
-      updatedStatus = "rejected";
+      updatedStatus = "canceled";
     }
 
     await updateFormPaymentStatus(
@@ -258,15 +259,20 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
                   <PaymentCaptureModal
                     openModal={openModal}
                     setOpenModal={setOpenModal}
-                    status={status[index]}
-                    amount={formatMoney(amount[index])}
-                    user={user[index]}
-                    index={index}
+                    status={status[paymentCaptureIndex]}
+                    amount={formatMoney(amount[paymentCaptureIndex])}
+                    user={user[paymentCaptureIndex]}
+                    index={paymentCaptureIndex}
                     response={response}
                     handleStatusChange={handleStatusChange}
                   />
                   <DropdownMenuButton trigger={StatusButton(status[index])}>
-                    <DropdownMenuButton.Item onClick={() => setOpenModal(true)}>
+                    <DropdownMenuButton.Item
+                      onClick={() => {
+                        setOpenModal(true);
+                        setPaymentCaptureIndex(index);
+                      }}
+                    >
                       <StatusLabel status="approved">approved</StatusLabel>
                     </DropdownMenuButton.Item>
 
@@ -274,7 +280,12 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
                       className={styles.separator}
                     />
 
-                    <DropdownMenuButton.Item onClick={() => setOpenModal(true)}>
+                    <DropdownMenuButton.Item
+                      onClick={() => {
+                        setOpenModal(true);
+                        setPaymentCaptureIndex(index);
+                      }}
+                    >
                       <StatusLabel status="rejected">rejected</StatusLabel>
                     </DropdownMenuButton.Item>
 
@@ -282,7 +293,12 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
                       className={styles.separator}
                     />
 
-                    <DropdownMenuButton.Item onClick={() => setOpenModal(true)}>
+                    <DropdownMenuButton.Item
+                      onClick={() => {
+                        setOpenModal(true);
+                        setPaymentCaptureIndex(index);
+                      }}
+                    >
                       <StatusLabel status="pending">pending</StatusLabel>
                     </DropdownMenuButton.Item>
                   </DropdownMenuButton>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Bug introduced where selecting on changing the payment status always defaulted to the last row in the form responses table. Now the button can render the accept/rejection/cancel view for the specific row in question.
![Recording 2025-03-02 at 19 21 44](https://github.com/user-attachments/assets/df0a9250-601b-49e9-86bd-c5b900d74218)

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
