### PR TITLE
Fix/Allow admins to Approve payments

### DIFF
--- a/server/controllers/account.controller.js
+++ b/server/controllers/account.controller.js
@@ -110,32 +110,6 @@ const AccountController = function () {
     }
   };
 
-  var getStripeAccountId = async function (accountId) {
-    const stripeAccount = await UserStripeAccounts.findByPk(accountId);
-    return stripeAccount.stripe_account_id;
-  };
-
-  var getClientSecret = async function (req, res, next) {
-    try {
-      const paymentIntentId = req.params["paymentIntentId"];
-      const stripeAccountId = await getStripeAccountId(
-        req.params["account_id"],
-      );
-
-      let paymentIntentIdStr = paymentIntentId.toString();
-      const paymentIntent = await Stripe.paymentIntents.retrieve(
-        paymentIntentIdStr,
-        {
-          stripeAccount: stripeAccountId,
-        },
-      );
-
-      res.status(200).json({ cleintSecret: paymentIntent.client_secret });
-    } catch (error) {
-      next(error);
-    }
-  };
-
   var getAllAccountsByGroupId = async function (req, res, next) {
     try {
       const groupId = req.params.group_id;
@@ -378,8 +352,6 @@ const AccountController = function () {
   return {
     createAccountConnection,
     createPaymentIntent,
-    getStripeAccountId,
-    getClientSecret,
     getAllAccountsByGroupId,
     calculateStripeStatus,
     getPublishableKey,

--- a/server/controllers/account.controller.js
+++ b/server/controllers/account.controller.js
@@ -246,37 +246,39 @@ const AccountController = function () {
         where: { email: email },
       });
 
-      const { stripe_account_id } = await UserStripeAccounts.findOne({
-        where: {
-          user_id: id,
-        },
+      const formPayment = await FormPayment.findOne({
+        where: { payment_intent_id: paymentIntentId },
       });
+
+      if (!formPayment) {
+        return {
+          success: false,
+          error: `no linked stripe account found for payment intent id: ${paymentIntentId}`,
+          status: 404,
+        };
+      }
 
       const retrievePaymentIntent = await getPaymentIntentStatus(
         paymentIntentId,
-        stripe_account_id,
+        formPayment.stripe_account_id_string,
       );
 
       if (!retrievePaymentIntent.success) {
-        return {
-          success: false,
-          error: retrievePaymentIntent.error,
-          status: retrievePaymentIntent.status,
-        };
+        return retrievePaymentIntent;
       }
 
       if (retrievePaymentIntent.data.status === "succeeded") {
         return {
-          success: true,
-          data: retrievePaymentIntent.data,
-          status: 200,
+          success: false,
+          data: `payment intent of status succeeded can not be captured: ${retrievePaymentIntent.data}`,
+          status: 304,
         };
       }
 
       const paymentIntent = await Stripe.paymentIntents.capture(
         paymentIntentId,
         {
-          stripeAccount: stripe_account_id,
+          stripeAccount: formPayment.stripe_account_id_string,
         },
       );
 
@@ -288,21 +290,15 @@ const AccountController = function () {
         };
       }
 
-      const formPaymentResult = await FormPayment.findOne({
-        where: { payment_intent_id: paymentIntentId },
-      });
+      const updates = {
+        internal_status_updated_by: id,
+        internal_status_updated_at: new Date(),
+      };
 
-      if (formPaymentResult) {
-        const updates = {
-          internal_status_updated_by: id,
-          internal_status_updated_at: new Date(),
-        };
-
-        await formPaymentResult.update(updates, { validate: true });
-      }
+      await formPayment.update(updates, { validate: true });
 
       if (formattedAnswers) {
-        const responseId = formPaymentResult.response_document_id;
+        const responseId = formPayment.response_document_id;
 
         await Response.updateOne(
           { _id: responseId },
@@ -315,10 +311,18 @@ const AccountController = function () {
         );
       }
 
-      return { success: true, data: paymentIntent, status: 200 };
+      return {
+        success: true,
+        data: `successfuly captured payment intent: ${paymentIntentId}`,
+        status: 200,
+      };
     } catch (error) {
       console.error(error);
-      return { success: false, error: error.message, status: 500 };
+      return {
+        success: false,
+        error: `process of capturing payment intent failed:  ${error.message}`,
+        status: 500,
+      };
     }
   };
 

--- a/server/controllers/account.controller.js
+++ b/server/controllers/account.controller.js
@@ -78,6 +78,7 @@ const AccountController = function () {
   var createPaymentIntent = async function (req, res, next) {
     try {
       let productObj = req.body;
+      productObj.stripeAccountIdString = req.params["account_id"];
 
       const paymentIntent = await Stripe.paymentIntents.create(
         {
@@ -91,7 +92,7 @@ const AccountController = function () {
           // application_fee_amount: productObj.transactionFee,
         },
         {
-          stripeAccount: req.params["account_id"],
+          stripeAccount: productObj.stripeAccountIdString,
         },
       );
 
@@ -329,7 +330,7 @@ const AccountController = function () {
       amount: formData.transactionAmount,
       payment_intent_id: formData.paymentIntentId,
       payment_intent_status: formData.paymentIntentStatus,
-      user_stripe_account_id: formData.userStripeAccountSqlId,
+      stripe_account_id_string: formData.stripeAccountIdString,
     });
   };
 

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -199,7 +199,7 @@ const FormPaymentController = function () {
     }
   };
 
-  var updatePaymentStatus = async function (req, res, next) {
+  var updatePaymentStatus = async function (req, res) {
     try {
       const { payment_intent_id, status, email, answers } = req.body;
 
@@ -211,9 +211,9 @@ const FormPaymentController = function () {
       );
 
       if (!formPayment.success) {
-        return res.status(500).json({
+        return res.status(formPayment.status).json({
           success: false,
-          error: "No response received from payment capture",
+          error: `process faled with error of : ${formPayment.error} `,
         });
       }
 

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -294,7 +294,7 @@ const FormPaymentController = function () {
       const formattedAnswers = response.formatted_answers;
       const userSelectedStatus = response.user_selected_status;
 
-      if (userSelectedStatus === "approved" && formattedAnswers) {
+      if (userSelectedStatus === "succeeded" && formattedAnswers) {
         const user = getUserDataFromAnswers(formattedAnswers, groupId);
 
         const updatedUserResponse =

--- a/server/migrations/20250304000850-update-form-payments-with-new-stripe-account-column-and-user-id.js
+++ b/server/migrations/20250304000850-update-form-payments-with-new-stripe-account-column-and-user-id.js
@@ -1,0 +1,106 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.addConstraint(
+        "UserStripeAccounts",
+        {
+          fields: ["stripe_account_id"],
+          type: "unique",
+          name: "unique_stripe_account_id",
+        },
+        { transaction },
+      );
+
+      await queryInterface.removeColumn(
+        "FormPayments",
+        "user_stripe_account_id",
+        {
+          transaction,
+        },
+      );
+
+      await queryInterface.addColumn(
+        "FormPayments",
+        "stripe_account_id_string",
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+          references: {
+            model: "UserStripeAccounts",
+            key: "stripe_account_id",
+          },
+          onUpdate: "CASCADE",
+          onDelete: "NO ACTION",
+        },
+        { transaction },
+      );
+
+      await queryInterface.addColumn("FormPayments", "payer_id", {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: "Users",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "SET NULL",
+        transaction,
+      });
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.removeColumn("FormPayments", "payer_id", {
+        transaction,
+      });
+
+      await queryInterface.removeColumn(
+        "FormPayments",
+        "stripe_account_id_string",
+        {
+          transaction,
+        },
+      );
+
+      await queryInterface.addColumn(
+        "FormPayments",
+        "user_stripe_account_id",
+        {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: {
+            model: "UserStripeAccounts",
+            key: "id",
+          },
+          onUpdate: "CASCADE",
+          onDelete: "SET NULL",
+        },
+        { transaction },
+      );
+
+      await queryInterface.removeConstraint(
+        "UserStripeAccounts",
+        "unique_stripe_account_id",
+        { transaction },
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/server/models/formpayment.js
+++ b/server/models/formpayment.js
@@ -23,6 +23,11 @@ module.exports = (sequelize, DataTypes) => {
         targetKey: "id",
       });
 
+      FormPayment.belongsTo(models.User, {
+        foreignKey: "payer_id",
+        targetKey: "id",
+      });
+
       FormPayment.belongsTo(models.PaymentMethod, {
         foreignKey: "payment_method_id",
         targetKey: "id",
@@ -34,8 +39,8 @@ module.exports = (sequelize, DataTypes) => {
       });
 
       FormPayment.belongsTo(models.UserStripeAccounts, {
-        foreignKey: "user_stripe_account_id",
-        targetKey: "id",
+        foreignKey: "stripe_account_id_string",
+        targetKey: "stripe_account_id",
       });
     }
   }
@@ -84,14 +89,18 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
-      user_stripe_account_id: {
-        type: DataTypes.INTEGER,
-        allowNull: true,
-      },
       response_document_id: {
         type: DataTypes.STRING,
         allowNull: true,
         unique: true,
+      },
+      stripe_account_id_string: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      payer_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
       },
     },
 

--- a/server/models/userstripeaccounts.js
+++ b/server/models/userstripeaccounts.js
@@ -17,8 +17,8 @@ module.exports = (sequelize, DataTypes) => {
         targetKey: "id",
       });
       UserStripeAccounts.hasMany(models.FormPayment, {
-        foreignKey: "user_stripe_account_id",
-        sourceKey: "id",
+        foreignKey: "stripe_account_id_string",
+        sourceKey: "stripe_account_id",
       });
     }
   }
@@ -30,6 +30,7 @@ module.exports = (sequelize, DataTypes) => {
       },
       stripe_account_id: {
         type: DataTypes.STRING,
+        unique: true,
         allowNull: false,
       },
       stripe_account_name: {

--- a/server/routes/account.routes.js
+++ b/server/routes/account.routes.js
@@ -11,12 +11,6 @@ module.exports = (checkJwt) => {
     "/:account_id/paymentIntent",
     AccountController.createPaymentIntent,
   );
-
-  router.get(
-    "/:account_id/paymentIntent/:paymentIntentId",
-    AccountController.getClientSecret,
-  );
-
   router.get("/:group_id", AccountController.getAllAccountsByGroupId);
   router.get("/key/publishable", AccountController.getPublishableKey);
 


### PR DESCRIPTION
### Description

Before only the owner of the stripe account could Approve a payment in teh response tab without returning a server error. 

1. updated the `formPayments` table to refrence the `userStripeAccounts` table `stripe_account_id` over the `user_id`

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
