### PR TITLE
Fix: Increase client max body size

### DIFF
--- a/client/src/components/FileUpload/FileUpload.tsx
+++ b/client/src/components/FileUpload/FileUpload.tsx
@@ -62,7 +62,7 @@ const FileUpload: React.FC<FileUploadProps> = ({ className, setFileValue }) => {
     accept: {
       "image/*": [],
     },
-    maxSize: 1024 * 1000 * 8,
+    maxSize: 1024 * 1000 * 10,
   });
 
   const style = useMemo(

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,7 @@ http {
 
   server {
     listen 80;
+    client_max_body_size 15m;
 
     location / {
       proxy_pass http://client:8080;


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Increases the client max body size. 
The default max by nginx is 1mb. We are accepting user images that are up to 8mb large but nginx was only allowing requests that were up to 1mb. So any requests with images that exceeded the default value were being rejected by nginx.

Here the max size is set to 15mb to allow room for larger requests while still setting a reasonable limit.
### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
[CV-103](https://cascarita.atlassian.net/browse/CV-103?atlOrigin=eyJpIjoiMTQxNmEzZmNiYTYyNDZlMGI2ZTQ4M2Y5YzkyODg5MGUiLCJwIjoiaiJ9)
