### PR TITLE
feat: edit modals populate with existing values for season and leagues modals

### DIFF
--- a/client/src/api/leagues/mutations.ts
+++ b/client/src/api/leagues/mutations.ts
@@ -1,6 +1,7 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createNewLeague, updateLeague, deleteLeague } from "./service";
 import { LeagueRequest } from "../../components/Forms/LeagueForm/types";
+import { getLeagueByGroupId } from "./service";
 
 export const useCreateLeague = () => {
   const queryClient = useQueryClient();
@@ -55,5 +56,13 @@ export const useDeleteLeague = () => {
         await queryClient.invalidateQueries({ queryKey: ["leagues"] });
       }
     },
+  });
+};
+
+export const useGetLeagueByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["leagues", groupId ? groupId : 0],
+    queryFn: getLeagueByGroupId,
+    enabled: groupId !== 0,
   });
 };

--- a/client/src/api/leagues/mutations.ts
+++ b/client/src/api/leagues/mutations.ts
@@ -1,7 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createNewLeague, updateLeague, deleteLeague } from "./service";
 import { LeagueRequest } from "../../components/Forms/LeagueForm/types";
-import { getLeagueByGroupId } from "./service";
 
 export const useCreateLeague = () => {
   const queryClient = useQueryClient();
@@ -56,13 +55,5 @@ export const useDeleteLeague = () => {
         await queryClient.invalidateQueries({ queryKey: ["leagues"] });
       }
     },
-  });
-};
-
-export const useGetLeagueByGroupId = (groupId: number) => {
-  return useQuery({
-    queryKey: ["leagues", groupId ? groupId : 0],
-    queryFn: getLeagueByGroupId,
-    enabled: groupId !== 0,
   });
 };

--- a/client/src/api/leagues/query.ts
+++ b/client/src/api/leagues/query.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLeagueByGroupId } from "./service";
+
+export const useGetLeagueByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["leagues", groupId ? groupId : 0],
+    queryFn: getLeagueByGroupId,
+    enabled: groupId !== 0,
+  });
+};

--- a/client/src/api/seasons/query.ts
+++ b/client/src/api/seasons/query.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeasonsByGroupId } from "./services";
+
+export const useGetSeasonByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["seasons", groupId ? groupId : 0],
+    queryFn: getSeasonsByGroupId,
+    enabled: groupId !== 0,
+  });
+};

--- a/client/src/components/Forms/LeagueForm/LeagueForm.tsx
+++ b/client/src/components/Forms/LeagueForm/LeagueForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styles from "../Form.module.css";
 import Modal from "../../Modal/Modal";
 import { LeagueFormProps, LeagueFormData, LeagueRequest } from "./types";
@@ -39,8 +39,10 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
     resolver: zodResolver(leagueSchema),
   });
 
-  setValue("name", leagueName || "");
-  setValue("description", leagueDescription);
+  useEffect(() => {
+    setValue("name", leagueName || "");
+    setValue("description", leagueDescription);
+  }, [leagueName, leagueDescription]);
 
   const createLeagueMutation = useCreateLeague();
   const updateLeagueMutation = useUpdateLeague();

--- a/client/src/components/Forms/LeagueForm/LeagueForm.tsx
+++ b/client/src/components/Forms/LeagueForm/LeagueForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styles from "../Form.module.css";
 import Modal from "../../Modal/Modal";
 import { LeagueFormProps, LeagueFormData, LeagueRequest } from "./types";
@@ -39,10 +39,8 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
     resolver: zodResolver(leagueSchema),
   });
 
-  useEffect(() => {
-    setValue("name", leagueName || "");
-    setValue("description", leagueDescription);
-  }, [leagueName, leagueDescription]);
+  setValue("name", leagueName || "");
+  setValue("description", leagueDescription);
 
   const createLeagueMutation = useCreateLeague();
   const updateLeagueMutation = useUpdateLeague();

--- a/client/src/components/Forms/LeagueForm/types.tsx
+++ b/client/src/components/Forms/LeagueForm/types.tsx
@@ -3,6 +3,8 @@ interface LeagueFormProps {
   afterSave: () => void | null;
   requestType?: "POST" | "PATCH" | "DELETE";
   leagueId?: number;
+  leagueName?: string;
+  leagueDescription?: string;
 }
 
 interface LeagueFormData {

--- a/client/src/components/Forms/SeasonForm/SeasonForm.tsx
+++ b/client/src/components/Forms/SeasonForm/SeasonForm.tsx
@@ -17,6 +17,10 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
   afterSave,
   requestType,
   seasonId,
+  seasonName,
+  seasonLeagueId,
+  seasonStartDate,
+  seasonEndDate,
   leagueData,
 }) => {
   const { t } = useTranslation("Seasons");
@@ -25,6 +29,7 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<SeasonFormData>({
     defaultValues: {
@@ -35,6 +40,23 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
     },
     resolver: zodResolver(seasonSchema),
   });
+
+  const parseDateTimeString = (dateString: string) => {
+    return new Date(dateString).toISOString().split("T")[0];
+  };
+
+  useEffect(() => {
+    setValue("name", seasonName || "");
+    setValue("league_id", Number(seasonLeagueId) || 0);
+    setValue(
+      "start_date",
+      seasonStartDate ? parseDateTimeString(seasonStartDate) : ""
+    );
+    setValue(
+      "end_date",
+      seasonEndDate ? parseDateTimeString(seasonEndDate) : ""
+    );
+  }, [seasonName, seasonLeagueId, seasonStartDate, seasonEndDate]);
 
   const createSeasonMutation = useCreateSeason();
   const updateSeasonMutation = useUpdateSeason();

--- a/client/src/components/Forms/SeasonForm/types.ts
+++ b/client/src/components/Forms/SeasonForm/types.ts
@@ -5,6 +5,10 @@ interface SeasonFormProps {
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
   seasonId?: number;
+  seasonName?: string;
+  seasonLeagueId?: number;
+  seasonStartDate?: string;
+  seasonEndDate?: string;
   leagueData?: LeagueType[];
 }
 

--- a/client/src/pages/Leagues/Leagues.tsx
+++ b/client/src/pages/Leagues/Leagues.tsx
@@ -2,24 +2,20 @@ import styles from "../pages.module.css";
 import Search from "../../components/Search/Search";
 import PrimaryButton from "../../components/PrimaryButton/PrimaryButton";
 import DropdownMenuButton from "../../components/DropdownMenuButton/DropdownMenuButton";
-// import SelectMenu from "../../components/SelectMenu/SelectMenu";
 import Modal from "../../components/Modal/Modal";
 import LeagueForm from "../../components/Forms/LeagueForm/LeagueForm";
 import { LeagueType } from "./types";
-import { useQuery } from "@tanstack/react-query";
 import DashboardTable from "../../components/DashboardTable/DashboardTable";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { getLeagueByGroupId } from "../../api/leagues/service";
 import { Outlet, useLocation } from "react-router-dom";
 import { FaPlus } from "react-icons/fa";
 import { useGroup } from "../../components/GroupProvider/GroupProvider";
+import { useGetLeagueByGroupId } from "../../api/leagues/mutations";
 
 const Leagues = () => {
   const { t } = useTranslation("Leagues");
 
-  // const [filter, setFilter] = useState("");
-  // const [sorts, setSorts] = useState("");
   const [currentLeagueName, setCurrentLeagueName] = useState("");
   const [currentLeagueDescription, setCurrentLeagueDescription] = useState("");
   const [currentLeagueId, setCurrentLeagueId] = useState(0);
@@ -27,19 +23,12 @@ const Leagues = () => {
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const { groupId } = useGroup();
 
-  useEffect(() => {}, [groupId]);
-
-  // const filterStatuses = [t("filterOptions.item1"), t("filterOptions.item2")];
-  // const sortStatuses = [t("sortOptions.item1"), t("sortOptions.item2")];
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ["leagues", groupId ? groupId : 0],
-    queryFn: getLeagueByGroupId,
-    enabled: groupId !== 0,
-  });
+  const { data, isLoading, isError } = useGetLeagueByGroupId(groupId);
+
   useEffect(() => {
     const handleDebounce = setTimeout(() => {
       setDebouncedQuery(searchQuery);

--- a/client/src/pages/Leagues/Leagues.tsx
+++ b/client/src/pages/Leagues/Leagues.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import { Outlet, useLocation } from "react-router-dom";
 import { FaPlus } from "react-icons/fa";
 import { useGroup } from "../../components/GroupProvider/GroupProvider";
-import { useGetLeagueByGroupId } from "../../api/leagues/mutations";
+import { useGetLeagueByGroupId } from "../../api/leagues/query";
 
 const Leagues = () => {
   const { t } = useTranslation("Leagues");

--- a/client/src/pages/Leagues/Leagues.tsx
+++ b/client/src/pages/Leagues/Leagues.tsx
@@ -21,6 +21,7 @@ const Leagues = () => {
   // const [filter, setFilter] = useState("");
   // const [sorts, setSorts] = useState("");
   const [currentLeagueName, setCurrentLeagueName] = useState("");
+  const [currentLeagueDescription, setCurrentLeagueDescription] = useState("");
   const [currentLeagueId, setCurrentLeagueId] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -49,9 +50,14 @@ const Leagues = () => {
     };
   }, [searchQuery]);
 
-  const handleEdit = (leagueName: string, leagueId: number) => {
+  const handleEdit = (
+    leagueName: string,
+    leagueId: number,
+    leagueDescription: string
+  ) => {
     setCurrentLeagueName(leagueName);
     setCurrentLeagueId(leagueId);
+    setCurrentLeagueDescription(leagueDescription);
     setIsEditOpen(true);
   };
 
@@ -62,7 +68,7 @@ const Leagues = () => {
   };
 
   const filteredData = data?.filter((league: LeagueType) =>
-    league.name.toLowerCase().includes(debouncedQuery.toLowerCase()),
+    league.name.toLowerCase().includes(debouncedQuery.toLowerCase())
   );
 
   const location = useLocation();
@@ -121,7 +127,9 @@ const Leagues = () => {
                 <td className={styles.tableData}>
                   <DropdownMenuButton>
                     <DropdownMenuButton.Item
-                      onClick={() => handleEdit(league.name, league.id)}
+                      onClick={() =>
+                        handleEdit(league.name, league.id, league.description)
+                      }
                     >
                       {t("edit")}
                     </DropdownMenuButton.Item>
@@ -149,6 +157,8 @@ const Leagues = () => {
             afterSave={() => setIsEditOpen(false)}
             requestType="PATCH"
             leagueId={currentLeagueId}
+            leagueName={currentLeagueName}
+            leagueDescription={currentLeagueDescription}
           />
         </Modal.Content>
       </Modal>

--- a/client/src/pages/Seasons/Seasons.tsx
+++ b/client/src/pages/Seasons/Seasons.tsx
@@ -39,8 +39,6 @@ const Seasons = () => {
   const { data, isLoading, isError } = useGetSeasonByGroupId(groupId);
   const { data: leagueData } = useGetLeagueByGroupId(groupId);
 
-  console.log("leagueData in MAIN: ", leagueData);
-
   useEffect(() => {
     const handleDebounce = setTimeout(() => {
       setDebouncedQuery(searchQuery);

--- a/server/controllers/season.controller.js
+++ b/server/controllers/season.controller.js
@@ -194,15 +194,15 @@ const SeasonController = {
       }
 
       Object.keys(req.body).forEach((key) => {
-        if (key !== "league_id") {
-          season[key] = req.body[key] ? req.body[key] : season[key];
-        }
+        season[key] = req.body[key] ? req.body[key] : season[key];
       });
 
       const { name, league_id } = season;
       const isUnique = await isNameUniqueWithinLeague(name, league_id);
       if (!isUnique) {
-        return res.status(400).json({ error: "Season name is not unique" });
+        return res
+          .status(400)
+          .json({ error: "Season name is not unique within league" });
       }
 
       await season.validate();


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
When you click on "edit" for the season and league modals, it will populate with the existing values

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
https://cascarita.atlassian.net/browse/CV-107

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
