### PR TITLE
Prevent Forms from Being Deleted with Payment Responses

### DIFF
--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -239,7 +239,7 @@ const FormController = function () {
       await Response.deleteMany({ form_id: form_id });
       await FormMongo.deleteOne({ _id: form_id });
 
-      return res.status(204).json("form got deleted. L bozo");
+      return res.status(204).json("form deleted successfully");
     } catch (error) {
       next(error);
     }

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -217,17 +217,29 @@ const FormController = function () {
         },
       });
       if (!formResponse) {
-        res.status(404);
-        throw new Error(`no form with form id: ${form_id}`);
+        res.status(404).json([`no form with form id: ${form_id}`]);
+      }
+
+      const formPayments = await FormPaymentController.getFormPaymentsByFormId(
+        form_id,
+      );
+
+      if (!formPayments.success) {
+        console.warn("failed to find form with form_id");
+        return res.status(formPayments.success).json(formPayments.error);
+      }
+
+      if (formPayments.data.length > 0) {
+        return res
+          .status(200)
+          .json({ error: "form cannot be deleted due to payment response(s)" });
       }
 
       await formResponse.destroy();
-
       await Response.deleteMany({ form_id: form_id });
-
       await FormMongo.deleteOne({ _id: form_id });
 
-      res.status(204).json();
+      return res.status(204).json("form got deleted. L bozo");
     } catch (error) {
       next(error);
     }

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -8,6 +8,38 @@ const AccountController = require("./account.controller");
 const UserController = require("./user.controller");
 
 const FormPaymentController = function () {
+  var getFormPaymentsByFormId = async function (form_id) {
+    try {
+      let formPayments = [];
+      let forms = await Form.findAll({
+        where: {
+          document_id: form_id,
+        },
+      });
+
+      for (let form of forms) {
+        let payments = await FormPayment.findAll({
+          where: {
+            form_id: form.id,
+          },
+        });
+        formPayments = formPayments.concat(payments);
+      }
+
+      return {
+        success: true,
+        data: formPayments,
+        status: 201,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: "failed to find form with form_id",
+        status: 500,
+      };
+    }
+  };
+
   var connectResponseToFormPayment = async function (responseData, responseId) {
     const paymentEntry = responseData.find(
       (item) => item.field?.type === "payment" && item.paymentIntentId,
@@ -179,30 +211,14 @@ const FormPaymentController = function () {
     const { form_id } = req.body;
 
     try {
-      let formPayments = [];
-      let forms = await Form.findAll({
-        where: {
-          document_id: form_id,
-        },
-      });
+      const formPayments = await getFormPaymentsByFormId(form_id);
 
-      for (let form of forms) {
-        let payments = await FormPayment.findAll({
-          where: {
-            form_id: form.id,
-          },
-        });
-        formPayments = formPayments.concat(payments);
+      if (!formPayments.success) {
+        console.warn("failed to find form with form_id");
+        return res.status(formPayments.success).json(formPayments.error);
       }
 
-      if (!formPayments) {
-        res.status(404);
-        throw new Error(
-          `no form payment record found with form document id: ${req.params.form_id}`,
-        );
-      }
-
-      return res.status(200).json(formPayments);
+      return res.status(200).json(formPayments.data);
     } catch (error) {
       next(error);
     }
@@ -392,6 +408,7 @@ const FormPaymentController = function () {
   };
 
   return {
+    getFormPaymentsByFormId,
     connectResponseToFormPayment,
     updateStripePayment,
     updateMongoPaymentResponse,


### PR DESCRIPTION
### Description

Add functionality to prevent admins from deleting forms when it has form payment responses

### Issue Link

[<!-- Jira Ticket-->](https://cascarita.atlassian.net/browse/CV-118?atlOrigin=eyJpIjoiNGUwMmU3YzEzM2RhNDE4ZWE1YjExNzNkMDAxOTlmOTAiLCJwIjoiaiJ9)

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
