### PR TITLE
fix: edit modal populate values divisions, teams, and players

### DIFF
--- a/client/src/api/divisions/query.ts
+++ b/client/src/api/divisions/query.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDivisionsBySeasonId, getDivisionsByGroupId } from "./service";
+
+export const useGetDivisionsBySeasonId = (seasonId: number) => {
+  return useQuery({
+    queryKey: ["divisions", seasonId],
+    queryFn: getDivisionsBySeasonId,
+    enabled: seasonId !== 0,
+  });
+};
+
+export const useGetDivisionsByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["divisions", groupId],
+    queryFn: getDivisionsByGroupId,
+    enabled: groupId !== 0,
+  });
+};

--- a/client/src/api/divisions/service.ts
+++ b/client/src/api/divisions/service.ts
@@ -6,7 +6,7 @@ import {
 
 type divisionQueryKey = [string, number];
 
-const getDivisionByGroupId = async ({
+const getDivisionsByGroupId = async ({
   queryKey,
 }: QueryFunctionContext<divisionQueryKey>) => {
   const [, groupId] = queryKey;
@@ -105,7 +105,7 @@ const deleteDivision = async (data: DivisionRequest): Promise<void> => {
 };
 export {
   getDivisionsBySeasonId,
-  getDivisionByGroupId,
+  getDivisionsByGroupId,
   createDivision,
   updateDivision,
   deleteDivision,

--- a/client/src/api/teams/query.ts
+++ b/client/src/api/teams/query.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTeamsByGroupId, getTeamsBySeasonDivisionId } from "./service";
+
+export const useGetTeamsBySeasonDivisionId = (
+  seasonId: number,
+  divisionId: number
+) => {
+  return useQuery({
+    queryKey: ["teams", seasonId, divisionId],
+    queryFn: getTeamsBySeasonDivisionId,
+    enabled: seasonId !== 0 && divisionId !== 0,
+  });
+};
+
+export const useGetTeamsByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["teams", groupId],
+    queryFn: getTeamsByGroupId,
+    enabled: groupId !== 0,
+  });
+};

--- a/client/src/api/users/mutations.ts
+++ b/client/src/api/users/mutations.ts
@@ -4,13 +4,13 @@ import {
   DeleteUserData,
   UpdateUserData,
   AddUserData,
-  GetSessionData,
+  PlayerSessionRequest,
 } from "../../components/Forms/UserForm/types";
 import {
   deleteUser,
   updateUser,
   addUser,
-  getSession,
+  getPlayerSession,
   updatePlayerTeams,
 } from "./service";
 import { PlayerRequest } from "../../components/Forms/PlayerForm/types";
@@ -54,14 +54,14 @@ export const useDeleteUser = () => {
   });
 };
 
-export const useGetSession = () => {
+export const useGetPlayerSession = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: GetSessionData) => getSession(data),
+    mutationFn: (data: PlayerSessionRequest) => getPlayerSession(data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["users"],
+        queryKey: ["players"],
       });
     },
   });

--- a/client/src/api/users/mutations.ts
+++ b/client/src/api/users/mutations.ts
@@ -74,7 +74,7 @@ export const useUpdatePlayerTeams = () => {
     mutationFn: (data: PlayerRequest) => updatePlayerTeams(data),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["users"],
+        queryKey: ["players"],
       });
     },
   });

--- a/client/src/api/users/query.ts
+++ b/client/src/api/users/query.ts
@@ -1,5 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCompleteUserSettings, getUser } from "./service";
+import {
+  getCompleteUserSettings,
+  getPlayersByGroupId,
+  getUser,
+} from "./service";
 
 export const useFetchUser = (email: string, token: string) => {
   return useQuery({
@@ -13,5 +17,13 @@ export const useGetCompleteUserSettings = (userId: number) => {
     queryKey: ["user_settings", userId ? userId : 0],
     queryFn: getCompleteUserSettings,
     enabled: userId !== 0,
+  });
+};
+
+export const useGetPlayersByGroupId = (groupId: number) => {
+  return useQuery({
+    queryKey: ["players", groupId],
+    queryFn: getPlayersByGroupId,
+    enabled: groupId !== 0,
   });
 };

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -2,7 +2,7 @@ import { QueryFunctionContext } from "@tanstack/react-query";
 import {
   DeleteUserData,
   UpdateUserData,
-  GetSessionData,
+  PlayerSessionRequest,
   AddUserData,
 } from "../../components/Forms/UserForm/types";
 import { PlayerRequest } from "../../components/Forms/PlayerForm/types";
@@ -242,14 +242,14 @@ const updatePlayerTeams = async (
   }
 };
 
-const getSession = async (data: GetSessionData) => {
+const getPlayerSession = async (data: PlayerSessionRequest) => {
   try {
     const response = await fetch(`/api/users/session`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(data.formData),
+      body: JSON.stringify(data),
     });
 
     const result = await response.json();
@@ -289,7 +289,7 @@ export {
   fetchUser,
   updatePlayerTeams,
   getPlayersByGroupId,
-  getSession,
+  getPlayerSession,
   getCompleteUserSettings,
   getUser,
 };

--- a/client/src/api/users/service.ts
+++ b/client/src/api/users/service.ts
@@ -222,9 +222,7 @@ const fetchUser = async (email: string, token: string) => {
   }
 };
 
-const updatePlayerTeams = async (
-  data: PlayerRequest
-): Promise<UserResponse> => {
+const updatePlayerTeams = async (data: PlayerRequest): Promise<void> => {
   try {
     const response = await fetch(`/api/users/${data.id}/players/teams`, {
       method: "PATCH",
@@ -234,8 +232,10 @@ const updatePlayerTeams = async (
       body: JSON.stringify(data),
     });
 
-    const result = await response.json();
-    return result;
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+    return;
   } catch (error) {
     console.error("Error updating user:", error);
     throw error;

--- a/client/src/api/users/types.ts
+++ b/client/src/api/users/types.ts
@@ -9,6 +9,7 @@ export interface UserResponse {
   language_id: number;
   created_at: Date;
   updated_at: Date;
+  error?: string;
 }
 
 export interface User {

--- a/client/src/components/FileUpload/FileUpload.tsx
+++ b/client/src/components/FileUpload/FileUpload.tsx
@@ -16,8 +16,14 @@ const rejectStyle = {
   borderColor: "#ff1744",
 };
 
-const FileUpload: React.FC<FileUploadProps> = ({ className, setFileValue }) => {
-  const [filePreview, setFilePreview] = React.useState<string>("");
+const FileUpload: React.FC<FileUploadProps> = ({
+  className,
+  setFileValue,
+  imagePreview,
+}) => {
+  const [filePreview, setFilePreview] = React.useState<string>(
+    imagePreview || ""
+  );
   const [errorMessage, setErrorMessage] = React.useState("");
 
   const onDropAccepted = useCallback((acceptedFiles: File[]) => {

--- a/client/src/components/FileUpload/types.ts
+++ b/client/src/components/FileUpload/types.ts
@@ -1,6 +1,7 @@
 interface FileUploadProps {
   className?: string;
   setFileValue?: (url?: File) => void;
+  imagePreview?: string;
 }
 
 export type { FileUploadProps };

--- a/client/src/components/Forms/DivisionForm/DivisionForm.tsx
+++ b/client/src/components/Forms/DivisionForm/DivisionForm.tsx
@@ -18,8 +18,9 @@ import { divisionSchema } from "./schema";
 const DivisionForm: React.FC<DivisionFormProps> = ({
   afterSave,
   divisionId,
+  seasonId,
+  divisionName,
   requestType,
-  // seasonId,
   seasonData,
 }) => {
   const { t } = useTranslation("Divisions");
@@ -33,15 +34,15 @@ const DivisionForm: React.FC<DivisionFormProps> = ({
     watch,
   } = useForm<DivisionFormData>({
     defaultValues: {
-      name: "",
-      season_id: 0,
+      name: divisionName || "",
+      season_id: seasonId || 0,
     },
     resolver: zodResolver(divisionSchema),
     mode: "onChange",
   });
 
   const groupId = Cookies.get("group_id") || 0;
-  const divisionName = watch("name");
+  const name = watch("name");
 
   const createDivisionMutation = useCreateDivision();
   const updateDivisionMutation = useUpdateDivision();
@@ -116,14 +117,14 @@ const DivisionForm: React.FC<DivisionFormProps> = ({
               </label>
               <input
                 {...register("name")}
-                className={`${styles.input} ${errors.name || requestError || divisionName.length > 50 ? styles.invalid : ""}`}
+                className={`${styles.input} ${errors.name || requestError || name.length > 50 ? styles.invalid : ""}`}
                 placeholder={t("formContent.namePlaceholder")}
                 id="divisionName"
               />
               {errors.name && (
                 <span className={styles.error}>{errors.name?.message}</span>
               )}
-              {!errors.name && divisionName.length > 50 && (
+              {!errors.name && name.length > 50 && (
                 <span className={styles.error}>
                   Division name cannot exceed 50 characters
                 </span>

--- a/client/src/components/Forms/DivisionForm/types.ts
+++ b/client/src/components/Forms/DivisionForm/types.ts
@@ -4,6 +4,7 @@ interface DivisionFormProps {
   //Use to set open state from true to false after form submission
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
+  divisionName?: string;
   divisionId?: number;
   seasonId?: number;
   seasonData?: SeasonType[];

--- a/client/src/components/Forms/PlayerForm/PlayerForm.tsx
+++ b/client/src/components/Forms/PlayerForm/PlayerForm.tsx
@@ -71,7 +71,7 @@ const PlayerForm: React.FC<PlayerFormProps> = ({
     };
 
     switch (requestType) {
-      case "PATCH":
+      case "PATCH": {
         const dataUpdate = await updatePlayerTeamsMutation.mutateAsync(
           updatePlayerTeamsData as PlayerRequest
         );
@@ -80,6 +80,7 @@ const PlayerForm: React.FC<PlayerFormProps> = ({
           return;
         }
         break;
+      }
       default:
         throw Error("No request type was supplied");
     }

--- a/client/src/components/Forms/PlayerForm/schema.ts
+++ b/client/src/components/Forms/PlayerForm/schema.ts
@@ -1,52 +1,89 @@
 import { z } from "zod";
 
-export const playerSchema = z.object({
-  league_id: z
-    .number({
-      required_error: "Please select a League",
-    })
-    .refine(
-      (id) => {
-        return id !== 0;
-      },
-      {
-        message: "Please select a League",
+export const playerSchema = z
+  .object({
+    link_to_team: z.boolean().optional(),
+    league_id: z
+      .number({
+        required_error: "Please select a League",
+      })
+      .refine(
+        (id) => {
+          return id !== 0;
+        },
+        {
+          message: "Please select a League",
+        }
+      ),
+    season_id: z
+      .number({
+        required_error: "Please select a Season",
+      })
+      .refine(
+        (id) => {
+          return id !== 0;
+        },
+        {
+          message: "Please select a Season",
+        }
+      ),
+    division_id: z
+      .number({
+        required_error: "Please select a Division",
+      })
+      .refine(
+        (id) => {
+          return id !== 0;
+        },
+        {
+          message: "Please select a Division",
+        }
+      ),
+    team_id: z
+      .number({
+        required_error: "Please select a Team",
+      })
+      .refine(
+        (id) => {
+          return id !== 0;
+        },
+        {
+          message: "Please select a Team",
+        }
+      ),
+  })
+  .superRefine((data, ctx) => {
+    if (data.link_to_team) {
+      if (!data.league_id || data.league_id === 0) {
+        ctx.addIssue({
+          path: ["league_id"],
+          message: "Please select a League",
+          code: z.ZodIssueCode.custom,
+        });
       }
-    ),
-  season_id: z
-    .number({
-      required_error: "Please select a Season",
-    })
-    .refine(
-      (id) => {
-        return id !== 0;
-      },
-      {
-        message: "Please select a Season",
+
+      if (!data.season_id || data.season_id === 0) {
+        ctx.addIssue({
+          path: ["season_id"],
+          message: "Please select a Season",
+          code: z.ZodIssueCode.custom,
+        });
       }
-    ),
-  division_id: z
-    .number({
-      required_error: "Please select a Division",
-    })
-    .refine(
-      (id) => {
-        return id !== 0;
-      },
-      {
-        message: "Please select a Division",
+
+      if (!data.division_id || data.division_id === 0) {
+        ctx.addIssue({
+          path: ["division_id"],
+          message: "Please select a Division",
+          code: z.ZodIssueCode.custom,
+        });
       }
-    ),
-  team_id: z
-    .number({
-      required_error: "Please select a Team",
-    })
-    .refine(
-      (id) => {
-        return id !== 0;
-      },
-      {
-        message: "Please select a Team",
+
+      if (!data.team_id || data.team_id === 0) {
+        ctx.addIssue({
+          path: ["team_id"],
+          message: "Please select a Team",
+          code: z.ZodIssueCode.custom,
+        });
       }
-    ),
-});
+    }
+  });

--- a/client/src/components/Forms/PlayerForm/schema.ts
+++ b/client/src/components/Forms/PlayerForm/schema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const playerSchema = z.object({
+  league_id: z
+    .number({
+      required_error: "Please select a League",
+    })
+    .refine(
+      (id) => {
+        return id !== 0;
+      },
+      {
+        message: "Please select a League",
+      }
+    ),
+  season_id: z
+    .number({
+      required_error: "Please select a Season",
+    })
+    .refine(
+      (id) => {
+        return id !== 0;
+      },
+      {
+        message: "Please select a Season",
+      }
+    ),
+  division_id: z
+    .number({
+      required_error: "Please select a Division",
+    })
+    .refine(
+      (id) => {
+        return id !== 0;
+      },
+      {
+        message: "Please select a Division",
+      }
+    ),
+  team_id: z
+    .number({
+      required_error: "Please select a Team",
+    })
+    .refine(
+      (id) => {
+        return id !== 0;
+      },
+      {
+        message: "Please select a Team",
+      }
+    ),
+});

--- a/client/src/components/Forms/PlayerForm/types.ts
+++ b/client/src/components/Forms/PlayerForm/types.ts
@@ -15,10 +15,10 @@ interface PlayerFormProps {
 }
 
 interface PlayerFormData {
-  leagueId: number;
-  seasonId: number;
-  divisionId: number;
-  teamId: number;
+  league_id: number;
+  season_id: number;
+  division_id: number;
+  team_id: number;
 }
 
 interface PlayerRequest {

--- a/client/src/components/Forms/PlayerForm/types.ts
+++ b/client/src/components/Forms/PlayerForm/types.ts
@@ -15,6 +15,7 @@ interface PlayerFormProps {
 }
 
 interface PlayerFormData {
+  link_to_team?: boolean;
   league_id: number;
   season_id: number;
   division_id: number;

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -22,12 +22,20 @@ import { teamSchema } from "./schema";
 const TeamForm: React.FC<TeamFormProps> = ({
   afterSave,
   requestType,
+  teamName,
+  seasonId,
+  divisionId,
+  teamLogo,
   teamId,
   divisionsData,
   seasonsData,
 }) => {
   const { t } = useTranslation("Teams");
   const [requestError, setRequestError] = useState("");
+  console.log("teamLogo", teamLogo, teamLogo ? false : true);
+  const [isChangingPhoto, setIsChangingPhoto] = useState(
+    teamLogo ? false : true
+  );
   const groupId = Number(Cookies.get("group_id")) || 0;
 
   const {
@@ -39,18 +47,18 @@ const TeamForm: React.FC<TeamFormProps> = ({
     watch,
   } = useForm<TeamFormData>({
     defaultValues: {
-      name: "",
-      season_id: 0,
-      division_id: 0,
+      name: teamName || "",
+      season_id: seasonId || 0,
+      division_id: divisionId || 0,
       file_url: undefined,
-      link_to_season: false,
+      link_to_season: divisionId && seasonId ? true : false,
     },
     resolver: zodResolver(teamSchema),
     mode: "onChange",
   });
 
   const isLinkSeason = watch("link_to_season");
-  const teamName = watch("name");
+  const name = watch("name");
   const createTeamMutation = useCreateTeam();
   const updateTeamMutation = useUpdateTeam();
   const deleteTeamMutation = useDeleteTeam();
@@ -143,14 +151,14 @@ const TeamForm: React.FC<TeamFormProps> = ({
               </label>
               <input
                 {...register("name")}
-                className={`${styles.input} ${errors.name || requestError || teamName.length > 30 ? styles.invalid : ""}`}
+                className={`${styles.input} ${errors.name || requestError || name.length > 30 ? styles.invalid : ""}`}
                 placeholder={t("formContent.namePlaceholder")}
                 id="teamName"
               />
               {errors.name && (
                 <span className={styles.error}>{errors.name?.message}</span>
               )}
-              {!errors.name && teamName.length > 30 && (
+              {!errors.name && name.length > 30 && (
                 <span className={styles.error}>
                   Team name cannot exceed 30 characters
                 </span>
@@ -234,12 +242,38 @@ const TeamForm: React.FC<TeamFormProps> = ({
 
             <div className={styles.inputContainer}>
               <label className={styles.label}>{t("formContent.logo")}</label>
-              <FileUpload
-                setFileValue={(url?: File) => {
-                  setValue("file_url", url);
-                }}
-                className={styles.logoInputContainer}
-              />
+              {!isChangingPhoto ? (
+                <div>
+                  <img
+                    src={teamLogo}
+                    alt="team logo"
+                    style={{ width: "150px", height: "150px" }}
+                    className={styles.logoPreview}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setIsChangingPhoto(true)}
+                    style={{
+                      background: "#007bff",
+                      color: "white",
+                      border: "none",
+                      marginTop: "10px",
+                      borderRadius: "25px",
+                      padding: "5px 10px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Change Logo
+                  </button>
+                </div>
+              ) : (
+                <FileUpload
+                  setFileValue={(url?: File) => {
+                    setValue("file_url", url);
+                  }}
+                  className={styles.logoInputContainer}
+                />
+              )}
             </div>
           </div>
 

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -10,7 +10,6 @@ import {
 } from "../../../api/teams/mutations";
 import DeleteForm from "../DeleteForm/DeleteForm";
 import { useTranslation } from "react-i18next";
-import Cookies from "js-cookie";
 import { DivisionType } from "../../../pages/Division/types";
 import { SeasonType } from "../../../pages/Seasons/types";
 import { SubmitHandler, useForm } from "react-hook-form";
@@ -18,6 +17,7 @@ import { useUploadPhotoS3 } from "../../../api/photo/mutations";
 import { UploadPhotoRequest } from "../../../api/photo/types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { teamSchema } from "./schema";
+import { useGroup } from "../../GroupProvider/GroupProvider";
 
 const TeamForm: React.FC<TeamFormProps> = ({
   afterSave,
@@ -32,11 +32,10 @@ const TeamForm: React.FC<TeamFormProps> = ({
 }) => {
   const { t } = useTranslation("Teams");
   const [requestError, setRequestError] = useState("");
-  console.log("teamLogo", teamLogo, teamLogo ? false : true);
   const [isChangingPhoto, setIsChangingPhoto] = useState(
     teamLogo ? false : true
   );
-  const groupId = Number(Cookies.get("group_id")) || 0;
+  const { groupId } = useGroup();
 
   const {
     register,

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -32,9 +32,6 @@ const TeamForm: React.FC<TeamFormProps> = ({
 }) => {
   const { t } = useTranslation("Teams");
   const [requestError, setRequestError] = useState("");
-  const [isChangingPhoto, setIsChangingPhoto] = useState(
-    teamLogo ? false : true
-  );
   const { groupId } = useGroup();
 
   const {
@@ -237,38 +234,13 @@ const TeamForm: React.FC<TeamFormProps> = ({
 
             <div className={styles.inputContainer}>
               <label className={styles.label}>{t("formContent.logo")}</label>
-              {!isChangingPhoto ? (
-                <div>
-                  <img
-                    src={teamLogo}
-                    alt="team logo"
-                    style={{ width: "150px", height: "150px" }}
-                    className={styles.logoPreview}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setIsChangingPhoto(true)}
-                    style={{
-                      background: "#007bff",
-                      color: "white",
-                      border: "none",
-                      marginTop: "10px",
-                      borderRadius: "25px",
-                      padding: "5px 10px",
-                      cursor: "pointer",
-                    }}
-                  >
-                    Change Logo
-                  </button>
-                </div>
-              ) : (
-                <FileUpload
-                  setFileValue={(url?: File) => {
-                    setValue("file_url", url);
-                  }}
-                  className={styles.logoInputContainer}
-                />
-              )}
+              <FileUpload
+                setFileValue={(url?: File) => {
+                  setValue("file_url", url);
+                }}
+                imagePreview={teamLogo}
+                className={styles.logoInputContainer}
+              />
             </div>
           </div>
 

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -138,11 +138,7 @@ const TeamForm: React.FC<TeamFormProps> = ({
           <p>{t("formContent.deleteMessage")}</p>
         </DeleteForm>
       ) : (
-        <form
-          className={styles.form}
-          // onSubmit={handleSubmit((data) => console.log(data))}
-          onSubmit={handleSubmit(onSubmit)}
-        >
+        <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
           <div style={{ display: "grid", gap: "24px" }}>
             <div className={styles.inputContainer}>
               <label className={styles.label} htmlFor="teamName">

--- a/client/src/components/Forms/TeamsForm/types.ts
+++ b/client/src/components/Forms/TeamsForm/types.ts
@@ -6,6 +6,10 @@ interface TeamFormProps {
   afterSave: () => void;
   requestType?: "POST" | "PATCH" | "DELETE";
   teamId?: number;
+  teamName?: string;
+  seasonId?: number;
+  divisionId?: number;
+  teamLogo?: string;
   divisionsData?: DivisionType[];
   seasonsData?: SeasonType[];
 }

--- a/client/src/components/Forms/UserForm/types.tsx
+++ b/client/src/components/Forms/UserForm/types.tsx
@@ -25,11 +25,9 @@ interface UpdatePlayerTeamsData {
   };
 }
 
-interface GetSessionData {
-  formData: {
-    division_id: number;
-    season_id: number;
-  };
+interface PlayerSessionRequest {
+  division_id: number;
+  season_id: number;
 }
 
 interface UpdateUserTeamData {
@@ -55,5 +53,5 @@ export type {
   UpdatePlayerTeamsData,
   AddUserData,
   UpdateUserTeamData,
-  GetSessionData,
+  PlayerSessionRequest,
 };

--- a/client/src/components/GroupProvider/GroupProvider.tsx
+++ b/client/src/components/GroupProvider/GroupProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, ReactNode } from "react";
-
+import Cookies from "js-cookie";
 interface GroupContextProps {
   groupId: number;
   setGroupId: (id: number) => void;
@@ -8,7 +8,9 @@ interface GroupContextProps {
 const GroupContext = createContext<GroupContextProps | undefined>(undefined);
 
 export const GroupProvider = ({ children }: { children: ReactNode }) => {
-  const [groupId, setGroupId] = useState<number>(0);
+  const [groupId, setGroupId] = useState<number>(
+    Number(Cookies.get("group_id")) || 0
+  );
 
   return (
     <GroupContext.Provider value={{ groupId, setGroupId }}>

--- a/client/src/pages/Players/Players.tsx
+++ b/client/src/pages/Players/Players.tsx
@@ -1,20 +1,20 @@
 import { useState, useEffect } from "react";
 import styles from "../pages.module.css";
 import Search from "../../components/Search/Search";
-import { getPlayersByGroupId } from "../../api/users/service";
-import * as Avatar from "@radix-ui/react-avatar";
 import DashboardTable from "../../components/DashboardTable/DashboardTable";
-import { useQueries } from "@tanstack/react-query";
 import DropdownMenuButton from "../../components/DropdownMenuButton/DropdownMenuButton";
 import { useTranslation } from "react-i18next";
-import Cookies from "js-cookie";
 import { PlayerType } from "./types";
 import Modal from "../../components/Modal/Modal";
-import { getDivisionsByGroupId } from "../../api/divisions/service";
-import { getSeasonsByGroupId } from "../../api/seasons/services";
-import { getTeamsByGroupId } from "../../api/teams/service";
-import { getLeaguesByGroupId } from "../../api/leagues/service";
 import PlayerForm from "../../components/Forms/PlayerForm/PlayerForm";
+import { useGroup } from "../../components/GroupProvider/GroupProvider";
+import { useGetTeamsByGroupId } from "../../api/teams/query";
+import { useGetPlayersByGroupId } from "../../api/users/query";
+import { useGetSeasonsByGroupId } from "../../api/seasons/query";
+import { useGetLeaguesByGroupId } from "../../api/leagues/query";
+import { useGetDivisionsByGroupId } from "../../api/divisions/query";
+import { FaUsers } from "react-icons/fa";
+import { Avatar } from "@radix-ui/themes";
 
 const Players = () => {
   const { t } = useTranslation("Players");
@@ -25,66 +25,13 @@ const Players = () => {
 
   const [isEditOpen, setIsEditOpen] = useState(false);
 
-  const groupId = Number(Cookies.get("group_id")) || 0;
+  const { groupId } = useGroup();
 
-  const result = useQueries({
-    queries: [
-      {
-        queryKey: ["players", groupId],
-        queryFn: async () =>
-          await getPlayersByGroupId({
-            queryKey: ["teams", groupId],
-            meta: undefined,
-            signal: new AbortController().signal,
-          }),
-        enabled: groupId !== 0,
-      },
-      {
-        queryKey: ["seasons", groupId],
-        queryFn: async () =>
-          await getSeasonsByGroupId({
-            queryKey: ["seasons", groupId],
-            meta: undefined,
-            signal: new AbortController().signal,
-          }),
-        enabled: groupId !== 0,
-      },
-      {
-        queryKey: ["divisions", groupId],
-        queryFn: async () =>
-          await getDivisionsByGroupId({
-            queryKey: ["divisions", groupId],
-            meta: undefined,
-            signal: new AbortController().signal,
-          }),
-        enabled: groupId !== 0,
-      },
-      {
-        queryKey: ["leagues", groupId],
-        queryFn: async () =>
-          await getLeaguesByGroupId({
-            queryKey: ["leagues", groupId],
-            meta: undefined,
-            signal: new AbortController().signal,
-          }),
-        enabled: groupId !== 0,
-      },
-      {
-        queryKey: ["teams", groupId],
-        queryFn: async () =>
-          await getTeamsByGroupId({
-            queryKey: ["teams", groupId],
-            meta: undefined,
-            signal: new AbortController().signal,
-          }),
-        enabled: groupId !== 0,
-      },
-    ],
-  });
-
-  const [playersQuery, seasonsQuery, divisionsQuery, leaguesQuery, teamsQuery] =
-    result;
-  const { data, isLoading } = playersQuery;
+  const { data: teams, isLoading } = useGetTeamsByGroupId(groupId);
+  const { data: players } = useGetPlayersByGroupId(groupId);
+  const { data: seasons } = useGetSeasonsByGroupId(groupId);
+  const { data: divisions } = useGetDivisionsByGroupId(groupId);
+  const { data: leagues } = useGetLeaguesByGroupId(groupId);
 
   const handleEdit = (player: PlayerType) => {
     setCurrentPlayer(player);
@@ -101,11 +48,7 @@ const Players = () => {
     };
   }, [searchQuery]);
 
-  useEffect(() => {
-    playersQuery.refetch();
-  }, [isEditOpen]);
-
-  const filteredData = data?.filter((player: PlayerType) =>
+  const filteredData = players?.filter((player: PlayerType) =>
     player.first_name.toLowerCase().includes(debouncedQuery.toLowerCase())
   );
 
@@ -114,7 +57,7 @@ const Players = () => {
       <div className={styles.sectionWrapper}>
         <div className={styles.filterSearch}>
           <div className={styles.dropdown}>
-            {data && data.length > 0 && (
+            {players && players.length > 0 && (
               <Search onSearchChange={setSearchQuery} />
             )}
           </div>
@@ -136,28 +79,29 @@ const Players = () => {
                 <td>{t("loading")}</td>
               </tr>
             ) : (
-              data?.map((player: PlayerType, idx: number) => (
+              players?.map((player: PlayerType, idx: number) => (
                 <tr key={idx} className={styles.tableRow}>
                   <td className={styles.tableData}>
-                    {/* <td className={styles.tableData}> */}
-                    <Avatar.Root className="AvatarRoot" key={player.picture}>
-                      <Avatar.Image
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "12px",
+                      }}
+                    >
+                      <Avatar
+                        src={(player && player.picture) || ""}
                         className={styles.avatar}
-                        src={player.picture || ""}
-                        alt={player.first_name + " " + player.last_name}
+                        fallback={
+                          <div className={styles.avatarFallback}>
+                            <FaUsers />
+                          </div>
+                        }
+                        radius="full"
+                        size={"4"}
                       />
-                      <Avatar.Fallback className="AvatarFallback">
-                        <img
-                          src="https://upload.wikimedia.org/wikipedia/commons/2/2c/Default_pfp.svg"
-                          alt={player.first_name + " " + player.last_name}
-                          className={styles.avatar}
-                        />
-                      </Avatar.Fallback>
-                    </Avatar.Root>
-                    <div style={{ display: "grid" }}>
-                      <p>{`${player.first_name} ${player.last_name}`}</p>
+                      {player.first_name} {player.last_name}
                     </div>
-                    {/* </td> */}
                   </td>
                   <td>
                     {player.teams && player.teams.length > 0 ? (
@@ -181,15 +125,7 @@ const Players = () => {
           </DashboardTable>
         )}
 
-        <Modal
-          open={isEditOpen}
-          onOpenChange={(isOpen) => {
-            setIsEditOpen(isOpen);
-            if (!isOpen) {
-              playersQuery.refetch();
-            }
-          }}
-        >
+        <Modal open={isEditOpen} onOpenChange={setIsEditOpen}>
           <Modal.Content
             title={`${t("edit")} ${currentPlayer?.first_name} ${currentPlayer?.last_name} Teams`}
           >
@@ -197,14 +133,13 @@ const Players = () => {
               <PlayerForm
                 afterSave={() => {
                   setIsEditOpen(false);
-                  playersQuery.refetch();
                 }}
                 requestType="PATCH"
                 player={currentPlayer}
-                leagues={leaguesQuery.data}
-                divisions={divisionsQuery.data}
-                seasons={seasonsQuery.data}
-                teams={teamsQuery.data}
+                leagues={leagues}
+                divisions={divisions}
+                seasons={seasons}
+                teams={teams}
               />
             )}
           </Modal.Content>

--- a/client/src/pages/Players/Players.tsx
+++ b/client/src/pages/Players/Players.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import Cookies from "js-cookie";
 import { PlayerType } from "./types";
 import Modal from "../../components/Modal/Modal";
-import { getDivisionByGroupId } from "../../api/divisions/service";
+import { getDivisionsByGroupId } from "../../api/divisions/service";
 import { getSeasonsByGroupId } from "../../api/seasons/services";
 import { getTeamsByGroupId } from "../../api/teams/service";
 import { getLeaguesByGroupId } from "../../api/leagues/service";
@@ -52,7 +52,7 @@ const Players = () => {
       {
         queryKey: ["divisions", groupId],
         queryFn: async () =>
-          await getDivisionByGroupId({
+          await getDivisionsByGroupId({
             queryKey: ["divisions", groupId],
             meta: undefined,
             signal: new AbortController().signal,


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
When you click on the edit button for the divisions, teams and player modals, you will have the option to edit the existing values.

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
https://cascarita.atlassian.net/browse/CV-107


### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
