### PR TITLE
fix: HEIC images preview for FileUpload component

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.28.0",
     "react-simple-placeholder-image": "^0.1.2",
+    "react-spinners": "^0.15.0",
     "react-switch": "^7.0.0",
     "stripe": "^16.12.0",
     "tailwind-merge": "^2.5.4",
@@ -64,8 +65,8 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.20.0",
-    "@jest/globals": "^29.7.0",
     "@hookform/resolvers": "^4.1.3",
+    "@jest/globals": "^29.7.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       react-simple-placeholder-image:
         specifier: ^0.1.2
         version: 0.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-spinners:
+        specifier: ^0.15.0
+        version: 0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-switch:
         specifier: ^7.0.0
         version: 7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -158,11 +161,7 @@ importers:
         version: 3.3.0
       '@eslint/js':
         specifier: ^9.20.0
-<<<<<<< HEAD
-        version: 9.20.0
-=======
         version: 9.21.0
->>>>>>> main
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
@@ -4041,6 +4040,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-spinners@0.15.0:
+    resolution: {integrity: sha512-ZO3/fNB9Qc+kgpG3SfdlMnvTX6LtLmTnOogb3W6sXIaU/kZ1ydEViPfZ06kSOaEsor58C/tzXw2wROGQu3X2pA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -9414,6 +9419,11 @@ snapshots:
       react: 18.3.1
 
   react-simple-placeholder-image@0.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-spinners@0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/client/src/components/FileUpload/FileUpload.tsx
+++ b/client/src/components/FileUpload/FileUpload.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import styles from "./FileUpload.module.css";
 import { FileRejection, useDropzone } from "react-dropzone";
 import { ImageIcon, Cross1Icon } from "@radix-ui/react-icons";
 import { FileUploadProps } from "./types";
+import PulseLoader from "react-spinners/PulseLoader";
 
 const focusedStyle = {
   borderColor: "#2196f3",
@@ -24,13 +25,24 @@ const FileUpload: React.FC<FileUploadProps> = ({
   const [filePreview, setFilePreview] = React.useState<string>(
     imagePreview || ""
   );
+  const [isLoading, setIsLoading] = React.useState(imagePreview ? true : false);
+
+  useEffect(() => {
+    if (imagePreview) {
+      setIsLoading(false);
+      setFilePreview(imagePreview);
+    } else {
+      setFilePreview("");
+    }
+  }, [imagePreview]);
+
   const [errorMessage, setErrorMessage] = React.useState("");
 
   const onDropAccepted = useCallback((acceptedFiles: File[]) => {
     const file = new FileReader();
 
     file.onload = () => {
-      setFilePreview(file.result as string);
+      setIsLoading(true);
       if (setFileValue) {
         setFileValue(acceptedFiles[0]);
       }
@@ -102,7 +114,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
             src={filePreview || undefined}
             alt=""
             onLoad={() => {
-              URL.revokeObjectURL(filePreview);
+              if (filePreview?.startsWith("blob:")) {
+                URL.revokeObjectURL(filePreview);
+              }
             }}
           />
           {filePreview && (
@@ -116,7 +130,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
       )}
 
       <input {...getInputProps()} />
-      {isDragActive ? (
+      {isLoading && !filePreview ? (
+        <PulseLoader color="#2196f3" loading={isLoading} />
+      ) : isDragActive ? (
         <div className={styles.dropZoneContent}>
           {!filePreview && (
             <>

--- a/client/src/components/FormInputComponents/Photo/Photo.tsx
+++ b/client/src/components/FormInputComponents/Photo/Photo.tsx
@@ -21,6 +21,8 @@ const Photo = ({ field, index }: FieldProps) => {
   const [fileUrl, setFileUrl] = useState<File | undefined>(undefined);
   register(`answers.${index}.photo`);
 
+  const [photoUrl, setPhotoUrl] = useState<string | undefined>(undefined);
+
   useEffect(() => {
     const uploadPhoto = async () => {
       if (fileUrl) {
@@ -30,6 +32,7 @@ const Photo = ({ field, index }: FieldProps) => {
           "player_photo"
         );
         setValue(`answers.${index}.photo`, uploadUrl.image_url);
+        setPhotoUrl(uploadUrl.image_url);
       } else {
         setValue(`answers.${index}.photo`, "");
       }
@@ -59,6 +62,7 @@ const Photo = ({ field, index }: FieldProps) => {
       )}
 
       <FileUpload
+        imagePreview={photoUrl}
         setFileValue={(url?: File) => {
           setFileUrl(url);
         }}

--- a/client/src/components/Forms/Form.module.css
+++ b/client/src/components/Forms/Form.module.css
@@ -26,6 +26,11 @@
   /* Optional: Adjust width as needed */
 }
 
+.logoInputContainer {
+  display: flex;
+  justify-content: center;
+}
+
 .copiedMessage {
   color: #aaaaaa;
   font-weight: 500;

--- a/client/src/components/Page/Page.module.css
+++ b/client/src/components/Page/Page.module.css
@@ -2,6 +2,7 @@
 .page {
   display: grid;
   grid-template-rows: 45px auto auto 1fr;
+  gap: 8px;
   position: relative;
   min-height: 100dvh;
   padding: 80px 12px 80px 18px;
@@ -18,6 +19,7 @@
   .page {
     padding: 32px 18px 8px 32px;
     max-height: 100dvh;
+    gap: 12px;
   }
 
   .title {

--- a/client/src/pages/pages.module.css
+++ b/client/src/pages/pages.module.css
@@ -13,7 +13,7 @@
   flex-wrap: wrap;
 }
 
-.dropdown > p {
+.dropdown>p {
   padding-left: 15px;
 }
 


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->

Upload now allows for HEIC images and adds react spinner to show loading for images

![Recording 2025-03-12 at 23 31 02](https://github.com/user-attachments/assets/dac709f5-7fc2-4d51-accf-50426ab6b9f8)

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
https://cascarita.atlassian.net/browse/CV-97

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
