### PR TITLE
Fix: Stripe Payment Approval Flow error 

### DIFF
--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -329,14 +329,14 @@ const FormPaymentController = function () {
           status: 404,
         };
       }
-      // sets up user data:
-      paymentData = await createPayerUser(formattedAnswers, groupId);
+
+      const paymentData = await createPayerUser(formattedAnswers, groupId);
 
       await existingFormPayment.update(paymentData, { valudate: true });
 
       return {
         success: true,
-        data: `user ${updatedUser.last_name} created and linked to form payment of: ${existingFormPayment.id}`,
+        data: `user created and linked to form payment of: ${existingFormPayment.id}`,
         status: 201,
       };
     } catch (error) {


### PR DESCRIPTION
### Description

When approving a response with a stripe payment, the user was not linked to the `formPayment` entry. The issue was that the `paymentData` was not declared correctly 

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
