### PR TITLE
Feature: Filter out form payments that do not have a response id

### DIFF
--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -218,7 +218,12 @@ const FormPaymentController = function () {
         return res.status(formPayments.success).json(formPayments.error);
       }
 
-      return res.status(200).json(formPayments.data);
+      const data = formPayments.data;
+      const completedFormPayment = data.filter(
+        (payment) => payment.response_document_id,
+      );
+
+      return res.status(200).json(completedFormPayment);
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
### Description

We can filter out formPayments with `response_document_id: null`. When a form is submitted, a `response_document_id` is linked to the corresponding `formPayment`. Therefore, in the Forms/Response view, we should only handle `formPayments` that have a valid `response_document_id`. Currently, the view uses every `formPayment` entry created for the form, regardless of submission status. Which causes responses to have missing status fields on the UI

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
