### PR TITLE
fix: enabling Sentry only for prod

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -6,20 +6,24 @@ import { createBrowserHistory } from "history";
 import "./index.module.css";
 import * as Sentry from "@sentry/react";
 
-Sentry.init({
-  dsn: "https://c3264debab8e92379efef056a7005b80@o4508911694315520.ingest.us.sentry.io/4508911696609280",
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
-  ],
-  // Tracing
-  tracesSampleRate: 1.0, //  Capture 100% of the transactions
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\/\/app\.cascarita\.io/],
-  // Session Replay
-  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-});
+const NODE_ENV_IS_PROD = (import.meta as any).env.PROD;
+
+if (NODE_ENV_IS_PROD) {
+  Sentry.init({
+    dsn: "https://c3264debab8e92379efef056a7005b80@o4508911694315520.ingest.us.sentry.io/4508911696609280",
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    // Tracing
+    tracesSampleRate: 1.0, //  Capture 100% of the transactions
+    // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+    tracePropagationTargets: ["localhost", /^https:\/\/app\.cascarita\.io/],
+    // Session Replay
+    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+    replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  });
+}
 
 type AppState = {
   returnTo?: string;

--- a/server/instrument.js
+++ b/server/instrument.js
@@ -1,17 +1,19 @@
-// Import with `import * as Sentry from "@sentry/node"` if you are using ESM
+require("dotenv").config();
 const Sentry = require("@sentry/node");
 
-Sentry.init({
-  dsn: "https://b2949253b19698b31aaaee4c49d722f1@o4508911694315520.ingest.us.sentry.io/4508911777742848",
-  integrations: [
-    // Add our Profiling integration
-  ],
+if (process.env.NODE_ENV !== "development") {
+  Sentry.init({
+    dsn: "https://b2949253b19698b31aaaee4c49d722f1@o4508911694315520.ingest.us.sentry.io/4508911777742848",
+    integrations: [
+      // Add our Profiling integration
+    ],
 
-  // Add Tracing by setting tracesSampleRate
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
+    // Add Tracing by setting tracesSampleRate
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
 
-  // Set sampling rate for profiling
-  // This is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
-});
+    // Set sampling rate for profiling
+    // This is relative to tracesSampleRate
+    profilesSampleRate: 1.0,
+  });
+}


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
[As noted in Sentry docs](https://docs.sentry.io/platforms/javascript/configuration/options/#enabled), conditionally rendering the `Sentry.init` call in order to only show Sentry on production

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
