### PR TITLE
Feature: Store Stripe Payment Web-hook Events

### DIFF
--- a/server/controllers/stripeEvent.controller.js
+++ b/server/controllers/stripeEvent.controller.js
@@ -13,6 +13,7 @@ const StripeEventController = function () {
       if (ignore) {
         return {
           success: true,
+          skip: true,
           data: `not tracking events of type : ${eventType}`,
           status: 200,
         };
@@ -24,7 +25,10 @@ const StripeEventController = function () {
 
       if (existingEvent) {
         return {
-          success: false,
+          success: true,
+          skip:
+            existingEvent.status === "completed" ||
+            existingEvent.status === "processing",
           data: `event ${eventId} already processed, skipping`,
           status: 200,
         };
@@ -40,6 +44,7 @@ const StripeEventController = function () {
 
       return {
         success: true,
+        skip: false,
         data: `successfully saved the event: ${eventId}`,
         status: 200,
       };

--- a/server/controllers/stripeEvent.controller.js
+++ b/server/controllers/stripeEvent.controller.js
@@ -65,7 +65,12 @@ const StripeEventController = function () {
         { where: { event_id: eventId } },
       );
     } catch (error) {
-      console.error(`Failed to update event status: ${error.message}`);
+      console.error({
+        event: "event_internal_status_update_failed",
+        eventId: eventId,
+        internal_status: status,
+        error: error.message,
+      });
     }
   };
 

--- a/server/controllers/stripeEvent.controller.js
+++ b/server/controllers/stripeEvent.controller.js
@@ -57,6 +57,17 @@ const StripeEventController = function () {
     }
   };
 
+  var updateEventStatus = async function (eventId, status) {
+    try {
+      await StripeEvent.update(
+        { status: status },
+        { where: { event_id: eventId } },
+      );
+    } catch (error) {
+      console.error(`Failed to update event status: ${error.message}`);
+    }
+  };
+
   var ignoreEvent = function (eventType) {
     const acceptableEvents = [
       "payment_intent.amount_capturable_updated",
@@ -68,6 +79,7 @@ const StripeEventController = function () {
   };
   return {
     validateEvent,
+    updateEventStatus,
   };
 };
 

--- a/server/controllers/stripeEvent.controller.js
+++ b/server/controllers/stripeEvent.controller.js
@@ -1,0 +1,69 @@
+"use strict";
+
+require("dotenv").config();
+
+const { StripeEvent } = require("../models");
+
+const StripeEventController = function () {
+  var validateEvent = async function (event) {
+    try {
+      const eventType = event.type;
+      const ignore = ignoreEvent(eventType);
+
+      if (ignore) {
+        return {
+          success: true,
+          data: `not tracking events of type : ${eventType}`,
+          status: 200,
+        };
+      }
+      const eventId = event.id;
+      const existingEvent = await StripeEvent.findOne({
+        where: { event_id: eventId },
+      });
+
+      if (existingEvent) {
+        return {
+          success: false,
+          data: `event ${eventId} already processed, skipping`,
+          status: 200,
+        };
+      }
+
+      await StripeEvent.create({
+        event_id: eventId,
+        event_type: eventType,
+        payload: event,
+        status: "received",
+        livemode: event.livemode,
+      });
+
+      return {
+        success: true,
+        data: `successfully saved the event: ${eventId}`,
+        status: 200,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `error handling storing Stripe event on databsae : ${error.message}`,
+        status: 500,
+      };
+    }
+  };
+
+  var ignoreEvent = function (eventType) {
+    const acceptableEvents = [
+      "payment_intent.amount_capturable_updated",
+      "payment_intent.succeeded",
+      "payment_intent.canceled",
+    ];
+
+    return !acceptableEvents.includes(eventType);
+  };
+  return {
+    validateEvent,
+  };
+};
+
+module.exports = StripeEventController();

--- a/server/controllers/stripeEvent.controller.js
+++ b/server/controllers/stripeEvent.controller.js
@@ -27,8 +27,8 @@ const StripeEventController = function () {
         return {
           success: true,
           skip:
-            existingEvent.status === "completed" ||
-            existingEvent.status === "processing",
+            existingEvent.internal_status === "completed" ||
+            existingEvent.internal_status === "processing",
           data: `event ${eventId} already processed, skipping`,
           status: 200,
         };
@@ -36,9 +36,10 @@ const StripeEventController = function () {
 
       await StripeEvent.create({
         event_id: eventId,
+        stripe_account_id: event.account,
         event_type: eventType,
         payload: event,
-        status: "received",
+        internal_status: "received",
         livemode: event.livemode,
       });
 
@@ -60,7 +61,7 @@ const StripeEventController = function () {
   var updateEventStatus = async function (eventId, status) {
     try {
       await StripeEvent.update(
-        { status: status },
+        { internal_status: status },
         { where: { event_id: eventId } },
       );
     } catch (error) {

--- a/server/controllers/stripeResources/formTransaction.controller.js
+++ b/server/controllers/stripeResources/formTransaction.controller.js
@@ -5,7 +5,7 @@ const FormPaymentController = require("../formPayment.controller");
 const StripeEventController = require("../stripeEvent.controller");
 
 const FormTransactionController = function () {
-  const endpointSecret = process.env.STRIPE_CONNECTED_ACCOUNTS_WEBHOOK_SECRET;
+  const endpointSecret = process.env.STRIPE_PAYMENTS_WEBHOOK_SECRET;
 
   var handleEvent = async function (req, res) {
     try {

--- a/server/migrations/20250313232855-create-stripe-event.js
+++ b/server/migrations/20250313232855-create-stripe-event.js
@@ -1,0 +1,88 @@
+"use strict";
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("StripeEvents", {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      event_id: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      stripe_account_id: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      event_type: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      internal_status: {
+        type: Sequelize.ENUM("received", "processing", "completed", "failed"),
+        allowNull: false,
+        defaultValue: "received",
+      },
+      payload: {
+        type: Sequelize.JSON,
+        allowNull: false,
+      },
+      result: {
+        type: Sequelize.JSON,
+        allowNull: true,
+      },
+      error_message: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      livemode: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+      received_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+      processed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal("CURRENT_TIMESTAMP"),
+        onUpdate: Sequelize.literal("CURRENT_TIMESTAMP"),
+      },
+    });
+
+    await queryInterface.addIndex("StripeEvents", ["event_id"], {
+      name: "idx_stripe_events_event_id",
+    });
+    await queryInterface.addIndex("StripeEvents", ["stripe_account_id"], {
+      name: "idx_stripe_events_stripe_account_id",
+    });
+    await queryInterface.addIndex("StripeEvents", ["internal_status"], {
+      name: "idx_stripe_events_internal_status",
+    });
+    await queryInterface.addIndex("StripeEvents", ["event_type"], {
+      name: "idx_stripe_events_event_type",
+    });
+    await queryInterface.addIndex("StripeEvents", ["livemode"], {
+      name: "idx_stripe_events_livemode",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("StripeEvents");
+  },
+};

--- a/server/models/stripeevent.js
+++ b/server/models/stripeevent.js
@@ -23,11 +23,15 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING(255),
         allowNull: false,
       },
+      stripe_account_id: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+      },
       event_type: {
         type: DataTypes.STRING(255),
         allowNull: false,
       },
-      status: {
+      internal_status: {
         type: DataTypes.ENUM("received", "processing", "completed", "failed"),
         allowNull: false,
         defaultValue: "received",

--- a/server/models/stripeevent.js
+++ b/server/models/stripeevent.js
@@ -1,0 +1,88 @@
+"use strict";
+const { Model } = require("sequelize");
+
+module.exports = (sequelize, DataTypes) => {
+  class StripeEvent extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  StripeEvent.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      event_id: {
+        type: DataTypes.STRING(255),
+        allowNull: false,
+      },
+      event_type: {
+        type: DataTypes.STRING(255),
+        allowNull: false,
+      },
+      status: {
+        type: DataTypes.ENUM("received", "processing", "completed", "failed"),
+        allowNull: false,
+        defaultValue: "received",
+      },
+      payload: {
+        type: DataTypes.JSON,
+        allowNull: false,
+      },
+      result: {
+        type: DataTypes.JSON,
+        allowNull: true,
+      },
+      error_message: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      livemode: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+      },
+      received_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      processed_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      modelName: "StripeEvent",
+      tableName: "StripeEvents",
+      createdAt: "created_at",
+      updatedAt: "updated_at",
+      indexes: [
+        {
+          name: "idx_stripe_events_event_id",
+          fields: ["event_id"],
+        },
+        {
+          name: "idx_stripe_events_status",
+          fields: ["status"],
+        },
+        {
+          name: "idx_stripe_events_event_type",
+          fields: ["event_type"],
+        },
+        {
+          name: "idx_stripe_events_livemode",
+          fields: ["livemode"],
+        },
+      ],
+    },
+  );
+  return StripeEvent;
+};

--- a/server/models/stripeevent.js
+++ b/server/models/stripeevent.js
@@ -74,8 +74,12 @@ module.exports = (sequelize, DataTypes) => {
           fields: ["event_id"],
         },
         {
+          name: "idx_stripe_events_stripe_account_id",
+          fields: ["stripe_account_id"],
+        },
+        {
           name: "idx_stripe_events_status",
-          fields: ["status"],
+          fields: ["internal_status"],
         },
         {
           name: "idx_stripe_events_event_type",


### PR DESCRIPTION
### Description

1.  migration created for a new table and model, `stripeEvents` . We will use this table to store webhook events. Store the `event_id`, `event_type`, `event_id` , `payload` , `internal_satatus` , `stripe_account_id` , `livemode` (these columns are also indexed on the db to it is easy to query and debug in the future)
2. `stripeEvent.controller.js` file created with a function that handle checking for duplicates , ignoring certain events (at the moment this table is only going to store payment events, we have two webhooks but the other webhook will not receive no where near events as the payment one. The other webhook is the `connectedAccount.controller.js` which handles updates to our users stripe account) and handle retries since stripe will use the same `event.id` (we store that) 
3. updated the way we handle webhook payments, by breaking it down to 2 functions. The original `handleEvent()` that stripe wehook will send the request too (sends it to a route in our server but that route calls this function). This function verifies the stripe request (make sure its a real stripe event) and **RETURNS 200** right away (stripe docs recommend this, stripe wants to know that our server got the event. What happens after that is on our server to handle and NOT SEND BACK A STATUS CODE. Then the function calls a `processEvent()` where we do all the db/bussiness logic. I make it so it never returns a status, only console logs for easier debugging and since we are now storing the event on the `stripeEvents` table, if something goes wrong where there was a db/logical error we can manually fix it since we have all the relevant event data on the db. @abanuelo  maybe we connect it with sentry, not sure if i need to throw an error to trigger sentry ?


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
