### PR TITLE
Fix: keep original image orientation

### DIFF
--- a/server/controllers/s3.controller.js
+++ b/server/controllers/s3.controller.js
@@ -28,7 +28,10 @@ const uploadImage = async (req, res) => {
   }
 
   var metadata = await sharp(req.file.buffer).metadata();
-  const exif = exifReader(metadata.exif);
+  var exif;
+  if (metadata.exif) {
+    exif = exifReader(metadata.exif);
+  }
 
   //If the file type is HEIC, convert it to JPEG
   if (req.file.mimetype === "image/heic") {
@@ -60,7 +63,7 @@ const uploadImage = async (req, res) => {
 
   const resizedBuffer = await sharp(req.file.buffer)
     .resize(width, height, { fit: "cover" })
-    .withMetadata({ orientation: exif.Image.Orientation})
+    .withMetadata({ orientation: exif.Image.Orientation || 1 })
     .toFormat("jpeg")
     .toBuffer();
 

--- a/server/controllers/s3.controller.js
+++ b/server/controllers/s3.controller.js
@@ -63,7 +63,7 @@ const uploadImage = async (req, res) => {
 
   const resizedBuffer = await sharp(req.file.buffer)
     .resize(width, height, { fit: "cover" })
-    .withMetadata({ orientation: exif.Image.Orientation || 1 })
+    .withMetadata({ orientation: exif?.Image.Orientation || 1 })
     .toFormat("jpeg")
     .toBuffer();
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
+        "exif-reader": "^2.0.2",
         "express": "^4.18.2",
         "express-oauth2-jwt-bearer": "^1.6.0",
         "heic-convert": "^2.1.0",
@@ -8205,6 +8206,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/exif-reader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/exif-reader/-/exif-reader-2.0.2.tgz",
+      "integrity": "sha512-CVFqcwdwFe2GnbbW7/Q7sUhVP5Ilaw7fuXQc6ad3AbX20uGfHhXTpkF/hQHPrtOuys9elFVgsUkvwfhfvjDa1A==",
+      "license": "MIT"
     },
     "node_modules/exit": {
       "version": "0.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
+    "exif-reader": "^2.0.2",
     "express": "^4.18.2",
     "express-oauth2-jwt-bearer": "^1.6.0",
     "heic-convert": "^2.1.0",


### PR DESCRIPTION
### Description
This change is to fix image orientation for images included in registration forms.

Uses image's exif metadata to read the image orientation and include that in the final image that is uploaded to S3. 
<!-- Provide a brief description of the changes introduced by this pull request -->

### Issue Link
[CV-157](https://cascarita.atlassian.net/browse/CV-157?atlOrigin=eyJpIjoiMWZhMTNjMTlmMGZmNDVjZWIxMmJkMjk0ZDU3YjUxY2UiLCJwIjoiaiJ9)
<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Additional Notes
Testing our latest release I noticed that some images were being rotated when they were uploaded through a phone. This PR is a fix for that issue.