### PR TITLE
FIX: remove left over form link logic

### DIFF
--- a/client/src/pages/NewForm/NewForm.tsx
+++ b/client/src/pages/NewForm/NewForm.tsx
@@ -72,7 +72,6 @@ const NewForm = () => {
   const [title, setTitle] = useState(
     location.state?.title ?? t("formTitlePlaceHolder")
   );
-  const [formLink, setFormLink] = useState(location.state?.link ?? null);
   const canvasRef = useRef<DNDCanvasRef>(null);
   const { getAccessTokenSilently } = useAuth0();
   let currentUser: User;
@@ -146,7 +145,6 @@ const NewForm = () => {
       currentUser?.id,
       "blank"
     );
-    setFormLink(`${window.location.origin}/forms/${response._id}`);
     setFormId(response._id);
     setFields(response.form_data.fields);
     setOpenModal(true);


### PR DESCRIPTION
### Description

Build is failing, we removed the `Preview Form` button but left the state declaration and the line that sets the `formLink` in `onCreate`

Build is working now 
### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
