### PR TITLE
fix: properly displaying delete form error messages

### DIFF
--- a/client/src/api/forms/query.ts
+++ b/client/src/api/forms/query.ts
@@ -1,10 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import { getFormByDocumentId } from "./service";
+import { getFormByDocumentId, getMongoForms } from "./service";
 
 export const useGetFormByDocumentId = (documentId: string) => {
   return useQuery({
     queryKey: ["forms", documentId],
     queryFn: getFormByDocumentId,
     enabled: documentId !== "",
+  });
+};
+
+export const useGetMongoForms = (groupId: number) => {
+  return useQuery({
+    queryKey: ["forms", groupId],
+    queryFn: getMongoForms,
+    enabled: groupId !== 0,
   });
 };

--- a/client/src/api/forms/service.ts
+++ b/client/src/api/forms/service.ts
@@ -99,7 +99,8 @@ export const deleteForm = async (id: string): Promise<FormResponse> => {
       throw new Error("Failed to delete form");
     }
 
-    return response.json();
+    const text = await response.text();
+    return text ? JSON.parse(text) : {};
   } catch (err) {
     console.error("Error deleting form:", err);
     throw err;
@@ -142,21 +143,6 @@ export const createMongoForm = async (
     return response.json();
   } catch (err) {
     console.error("Error creating form:", err);
-    throw err;
-  }
-};
-
-export const getMongoForms = async (groupId: number) => {
-  try {
-    const response = await fetch(`/api/groups/${groupId}/forms`);
-
-    if (!response.ok) {
-      throw new Error(`Error fetching forms: ${response.statusText}`);
-    }
-
-    return response.json();
-  } catch (err) {
-    console.error("Error fetching forms:", err);
     throw err;
   }
 };
@@ -416,6 +402,26 @@ export const getFormByDocumentId = async ({
     return response.json();
   } catch (err) {
     console.error("Error fetching form:", err);
+    throw err;
+  }
+};
+
+type MongoFormQueryKey = [string, number];
+
+export const getMongoForms = async ({
+  queryKey,
+}: QueryFunctionContext<MongoFormQueryKey>) => {
+  const [, groupId] = queryKey;
+  try {
+    const response = await fetch(`/api/groups/${groupId}/forms`);
+
+    if (!response.ok) {
+      throw new Error(`Error fetching forms: ${response.statusText}`);
+    }
+
+    return response.json();
+  } catch (err) {
+    console.error("Error fetching forms:", err);
     throw err;
   }
 };

--- a/client/src/api/forms/types.ts
+++ b/client/src/api/forms/types.ts
@@ -90,7 +90,7 @@ export interface GetFormsParams {
 }
 
 export interface FormResponse {
-  id: number;
+  id?: number;
   error?: string;
 }
 

--- a/client/src/components/Forms/DeleteForm/types.tsx
+++ b/client/src/components/Forms/DeleteForm/types.tsx
@@ -4,4 +4,8 @@ interface DeleteFormProps extends React.ComponentPropsWithoutRef<"form"> {
   children?: React.ReactNode;
 }
 
-export type { DeleteFormProps };
+interface DeleteFormData {
+  form_id: string;
+}
+
+export type { DeleteFormProps, DeleteFormData };

--- a/client/src/pages/Forms/Forms.tsx
+++ b/client/src/pages/Forms/Forms.tsx
@@ -106,8 +106,8 @@ const DeleteFormModal: React.FC<DeleteFormModalProps> = ({
           className={styles.form}
           onSubmit={(e) => handleDelete(e, formId)}
         >
-          {responseError && <p style={{ color: "red" }}>{responseError}</p>}
           <p>Are you sure you want to delete this form?</p>
+          {responseError && <p style={{ color: "red" }}>{responseError}</p>}
         </DeleteForm>
       </Modal.Content>
     </Modal>

--- a/client/src/pages/Forms/Forms.tsx
+++ b/client/src/pages/Forms/Forms.tsx
@@ -8,22 +8,19 @@ import styles from "../pages.module.css";
 import ShareButton from "../../components/ShareButton/ShareButton";
 import { useNavigate } from "react-router-dom";
 import { Form } from "./types";
-import { useAuth0 } from "@auth0/auth0-react";
 import { useTranslation } from "react-i18next";
-import {
-  deleteForm,
-  getMongoFormById,
-  getMongoForms,
-} from "../../api/forms/service";
+import { getMongoFormById } from "../../api/forms/service";
 import Modal from "../../components/Modal/Modal";
 import React from "react";
 import ShareForm from "../../components/Forms/ShareForm/ShareForm";
-import Cookies from "js-cookie";
-import { fetchUser } from "../../api/users/service";
 import DashboardTable from "../../components/DashboardTable/DashboardTable";
 import useResponsiveHeader from "../../hooks/useResponsiveHeader";
 import FormTemplateForm from "../../components/Forms/RegistrationTemplateForm/RegistrationTemplateForm";
 import DeleteForm from "../../components/Forms/DeleteForm/DeleteForm";
+import { useDeleteForm } from "../../api/forms/mutations";
+import { useGetMongoForms } from "../../api/forms/query";
+import { useGroup } from "../../components/GroupProvider/GroupProvider";
+import { FetchedForm } from "../FormPage/types";
 
 interface ShareModalProps {
   formLink: string;
@@ -72,25 +69,54 @@ const CreateTemplateModal: React.FC<CreateTemplateModalProps> = ({
 interface DeleteFormModalProps {
   isOpen: boolean;
   onOpen: (isOpen: boolean) => void;
+  formId: string;
 }
-
 const DeleteFormModal: React.FC<DeleteFormModalProps> = ({
   isOpen,
   onOpen,
-}) => (
-  <Modal open={isOpen} onOpenChange={onOpen}>
-    <Modal.Content title="Delete Form">
-      <DeleteForm destructBtnLabel={"Yes, I'm sure"} className={styles.form}>
-        <p>Are you sure you want to delete this form?</p>
-      </DeleteForm>
-    </Modal.Content>
-  </Modal>
-);
+  formId,
+}) => {
+  const deleteMutation = useDeleteForm();
+  const [responseError, setResponseError] = useState("");
+
+  const handleDelete = async (
+    e: React.FormEvent<HTMLFormElement>,
+    formId: string
+  ) => {
+    e.preventDefault();
+    try {
+      const deleteResult = await deleteMutation.mutateAsync(formId);
+      console.log(deleteResult);
+      if (deleteResult.error) {
+        setResponseError(deleteResult.error);
+      } else {
+        onOpen(false);
+      }
+    } catch (error) {
+      console.error("Unexpected error during form deletion:", error);
+      setResponseError("Unexpected error occurred");
+    }
+  };
+
+  return (
+    <Modal open={isOpen} onOpenChange={onOpen}>
+      <Modal.Content title="Delete Form">
+        <DeleteForm
+          destructBtnLabel={"Yes, I'm sure"}
+          className={styles.form}
+          onSubmit={(e) => handleDelete(e, formId)}
+        >
+          {responseError && <p style={{ color: "red" }}>{responseError}</p>}
+          <p>Are you sure you want to delete this form?</p>
+        </DeleteForm>
+      </Modal.Content>
+    </Modal>
+  );
+};
 
 const Forms = () => {
   const { t } = useTranslation("Forms");
   const [sorts, setSorts] = useState("");
-  const [forms, setForms] = useState<Form[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -99,7 +125,8 @@ const Forms = () => {
   const sortStatuses = [t("sortOptions.item1"), t("sortOptions.item2")];
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState(searchQuery);
-  const { getAccessTokenSilently } = useAuth0();
+  const [currentFormId, setCurrentFormId] = useState("");
+  const { groupId } = useGroup();
 
   const headers = useResponsiveHeader(
     [t("col1"), t("col2"), t("col4"), t("col5")],
@@ -116,15 +143,18 @@ const Forms = () => {
     };
   }, [searchQuery]);
 
+  const { data: forms, refetch } = useGetMongoForms(groupId);
+
   useEffect(() => {
-    (async () => {
-      const token = await getAccessTokenSilently();
-      const email = Cookies.get("email") || "";
-      const user = await fetchUser(email, token);
-      const mongoForms = await getMongoForms(user?.group_id ?? -1);
-      setForms(mongoForms);
-    })();
-  }, []);
+    setSorts(t("sortOptions.item1"));
+  }, [t]);
+
+  useEffect(() => {
+    if (!isDeleteOpen) {
+      // Re-fetch forms when delete modal is closed
+      refetch();
+    }
+  }, [isDeleteOpen]);
 
   // const handleNewFormClick = () => {
   //   navigate("/forms/edit");
@@ -140,8 +170,8 @@ const Forms = () => {
   };
 
   const onDelete = async (id: string) => {
+    setCurrentFormId(id);
     setIsDeleteOpen(true);
-    await deleteForm(id);
   };
 
   const onOpen = async (id: string) => {
@@ -225,7 +255,7 @@ const Forms = () => {
         <p className={styles.noItemsMessage}>No forms to display...</p>
       ) : (
         <DashboardTable headers={headers} headerColor="light">
-          {filteredData?.map((form, index) => (
+          {filteredData?.map((form: FetchedForm, index: number) => (
             <tr key={index} className={styles.tableRow}>
               <td className={styles.tableData}>
                 <p>
@@ -288,6 +318,7 @@ const Forms = () => {
         <DeleteFormModal
           isOpen={isDeleteOpen}
           onOpen={(isOpen: boolean) => setIsDeleteOpen(isOpen)}
+          formId={currentFormId}
         />
       )}
     </Page>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
BE returns an `{'error': '...'}` response when a form is flagged as unable to be deleted as it contains form responses. Allowing FE to capture these changes

#### Failure to delete form with responses
![Recording 2025-03-18 at 20 59 11](https://github.com/user-attachments/assets/1cad839c-76bd-42c1-b5ad-c944b97f12d1)


#### Successful form deletion
![Recording 2025-03-18 at 20 59 55](https://github.com/user-attachments/assets/11041906-6fc9-429a-ac0f-a7ad4e3b994c)


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
https://cascarita.atlassian.net/browse/CV-144

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
