### PR TITLE
Feat: Added Toast for confirmation and error messages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "react-simple-placeholder-image": "^0.1.2",
     "react-spinners": "^0.15.0",
     "react-switch": "^7.0.0",
+    "react-toastify": "^11.0.5",
     "stripe": "^16.12.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss": "^3.4.15",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       react-switch:
         specifier: ^7.0.0
         version: 7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-toastify:
+        specifier: ^11.0.5
+        version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       stripe:
         specifier: ^16.12.0
         version: 16.12.0
@@ -4204,6 +4207,12 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-toastify@11.0.5:
+    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -9732,6 +9741,12 @@ snapshots:
   react-switch@7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-toastify@11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 

--- a/client/src/api/forms/service.ts
+++ b/client/src/api/forms/service.ts
@@ -221,9 +221,11 @@ export const sendEmail = async (emails: string[], formLink: string) => {
     });
 
     if (!response.ok) {
-      throw new Error(`Error emailing form: ${response.statusText}`);
+      const errorData = await response.json();
+      return { error: errorData.error || "An unexpected error occurred" };
     }
-    return response.json();
+
+    return { success: true };
   } catch (err) {
     console.error("Error emailing responses:", err);
     throw err;

--- a/client/src/components/Forms/DivisionForm/DivisionForm.tsx
+++ b/client/src/components/Forms/DivisionForm/DivisionForm.tsx
@@ -14,6 +14,7 @@ import { SeasonType } from "../../../pages/Seasons/types";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { divisionSchema } from "./schema";
+import { toast } from "react-toastify";
 
 const DivisionForm: React.FC<DivisionFormProps> = ({
   afterSave,
@@ -66,7 +67,10 @@ const DivisionForm: React.FC<DivisionFormProps> = ({
         );
         if (dataPost.error) {
           setRequestError(dataPost.error);
+          toast.error(dataPost.error);
           return;
+        } else {
+          toast.success("Division Created Successfully");
         }
         break;
       }
@@ -78,7 +82,10 @@ const DivisionForm: React.FC<DivisionFormProps> = ({
         } as DivisionRequest);
         if (dataUpdate.error) {
           setRequestError(dataUpdate.error);
+          toast.error(dataUpdate.error);
           return;
+        } else {
+          toast.success("Division Updated Successfully");
         }
         break;
       }
@@ -92,9 +99,10 @@ const DivisionForm: React.FC<DivisionFormProps> = ({
 
   const onDelete = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    deleteDivisionMutation.mutate({
+    deleteDivisionMutation.mutateAsync({
       id: divisionId ? divisionId : 0,
     } as DivisionRequest);
+    toast.success("Division Deleted Successfully");
     afterSave();
   };
 

--- a/client/src/components/Forms/LeagueForm/LeagueForm.tsx
+++ b/client/src/components/Forms/LeagueForm/LeagueForm.tsx
@@ -13,6 +13,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { leagueSchema } from "./schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useGroup } from "../../GroupProvider/GroupProvider";
+import { toast } from "react-toastify";
 
 const LeagueForm: React.FC<LeagueFormProps> = ({
   afterSave,
@@ -61,7 +62,10 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
         );
         if (dataPost.error) {
           setError(dataPost.error);
+          toast.error(dataPost.error);
           return;
+        } else {
+          toast.success("League Created Successfully");
         }
         break;
       }
@@ -72,7 +76,10 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
         } as LeagueRequest);
         if (dataUpdate.error) {
           setError(dataUpdate.error);
+          toast.error(dataUpdate.error);
           return;
+        } else {
+          toast.success("League Updated Successfully");
         }
         break;
       }
@@ -87,8 +94,9 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
     e.preventDefault();
     deleteLeagueMutation.mutate({
       id: leagueId ? leagueId : 0,
-    } as LeagueRequest);
-    afterSave();
+    } as LeagueRequest),
+      toast.success("League Deleted Successfully"),
+      afterSave();
   };
 
   return (

--- a/client/src/components/Forms/LeagueForm/LeagueForm.tsx
+++ b/client/src/components/Forms/LeagueForm/LeagueForm.tsx
@@ -94,9 +94,10 @@ const LeagueForm: React.FC<LeagueFormProps> = ({
     e.preventDefault();
     deleteLeagueMutation.mutate({
       id: leagueId ? leagueId : 0,
-    } as LeagueRequest),
-      toast.success("League Deleted Successfully"),
-      afterSave();
+    } as LeagueRequest);
+
+    toast.success("League Deleted Successfully");
+    afterSave();
   };
 
   return (

--- a/client/src/components/Forms/SeasonForm/SeasonForm.tsx
+++ b/client/src/components/Forms/SeasonForm/SeasonForm.tsx
@@ -104,8 +104,9 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
     e.preventDefault();
     deleteSeasonMutation.mutateAsync({
       id: seasonId ? seasonId : 0,
-    } as SeasonRequest),
-      toast.success("Season Deleted Successfully");
+    } as SeasonRequest);
+
+    toast.success("Season Deleted Successfully");
     afterSave();
   };
 

--- a/client/src/components/Forms/SeasonForm/SeasonForm.tsx
+++ b/client/src/components/Forms/SeasonForm/SeasonForm.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { seasonSchema } from "./schema";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "react-toastify";
 
 const SeasonForm: React.FC<SeasonFormProps> = ({
   afterSave,
@@ -71,7 +72,10 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
         );
         if (dataPost.error) {
           setError(dataPost.error);
+          toast.error(dataPost.error);
           return;
+        } else {
+          toast.success("Season Created Successfully");
         }
         break;
       }
@@ -82,7 +86,10 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
         } as SeasonRequest);
         if (dataUpdate.error) {
           setError(dataUpdate.error);
+          toast.error(dataUpdate.error);
           return;
+        } else {
+          toast.success("Season Created Successfully");
         }
         break;
       }
@@ -95,9 +102,10 @@ const SeasonForm: React.FC<SeasonFormProps> = ({
 
   const onDelete = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    deleteSeasonMutation.mutate({
+    deleteSeasonMutation.mutateAsync({
       id: seasonId ? seasonId : 0,
-    } as SeasonRequest);
+    } as SeasonRequest),
+      toast.success("Season Deleted Successfully");
     afterSave();
   };
 

--- a/client/src/components/Forms/ShareForm/ShareForm.tsx
+++ b/client/src/components/Forms/ShareForm/ShareForm.tsx
@@ -2,31 +2,29 @@ import React, { useRef, useState } from "react";
 import styles from "../Form.module.css";
 import { ShareFormProps } from "./types";
 import { sendEmail } from "../../../api/forms/service";
+import { toast } from "react-toastify";
 
 const ShareForm: React.FC<ShareFormProps> = ({ afterClose, formLink }) => {
   const textBoxRef = useRef<HTMLInputElement>(null);
-  const [copied, setCopied] = useState<boolean>(false);
-  const [emailed, setEmailed] = useState<boolean>(false);
   const [email, setEmail] = useState<string>("");
 
   const handleEmail = async (emails: string[], formLink: string) => {
-    await sendEmail(emails, formLink);
+    const response = await sendEmail(emails, formLink);
+    if (response.error) {
+      toast.error("Specify at least one email");
+    } else {
+      toast.success("Form shared! 🎉");
+    }
   };
 
   const handleCopy = () => {
     if (textBoxRef.current) {
       const text = textBoxRef.current.innerText;
-      navigator.clipboard
-        .writeText(text)
-        .then(() => {
-          setCopied(true);
-          setTimeout(() => {
-            setCopied(false);
-          }, 5000);
-        })
-        .catch((err) => {
-          console.error("Failed to copy text: ", err);
-        });
+      toast.success("Copied to clipboard!");
+      navigator.clipboard.writeText(text).catch((err) => {
+        toast.error("Failed to copy text");
+        console.error("Failed to copy text: ", err);
+      });
     }
   };
 
@@ -35,8 +33,6 @@ const ShareForm: React.FC<ShareFormProps> = ({ afterClose, formLink }) => {
       <hr />
       <div>
         <label className={styles.boldLabel}>Form Link</label>
-        {copied && <p className={styles.copiedMessage}>Copied to clipboard!</p>}
-        {emailed && <p className={styles.copiedMessage}>Emails sent!</p>}
         <div className={styles.shareContainer}>
           <p ref={textBoxRef}>{formLink}</p>
           <button
@@ -66,12 +62,7 @@ const ShareForm: React.FC<ShareFormProps> = ({ afterClose, formLink }) => {
                 .map((e) => e.trim())
                 .filter((e) => e);
               const formLink = textBoxRef.current?.innerText || "";
-              setEmailed(true);
-              handleEmail(emails, formLink).finally(() => {
-                setTimeout(() => {
-                  setEmailed(false);
-                }, 2000);
-              });
+              handleEmail(emails, formLink).finally();
             }}
           >
             send

--- a/client/src/components/Forms/TeamsForm/TeamForm.tsx
+++ b/client/src/components/Forms/TeamsForm/TeamForm.tsx
@@ -17,6 +17,7 @@ import { uploadPhotoToS3 } from "../../../api/photo/service";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { teamSchema } from "./schema";
 import { useGroup } from "../../GroupProvider/GroupProvider";
+import { toast } from "react-toastify";
 
 const TeamForm: React.FC<TeamFormProps> = ({
   afterSave,
@@ -93,7 +94,10 @@ const TeamForm: React.FC<TeamFormProps> = ({
         );
         if (dataPost.error) {
           setRequestError(dataPost.error);
+          toast.error(dataPost.error);
           return;
+        } else {
+          toast.success("Team Created Successfully");
         }
         break;
       }
@@ -105,7 +109,10 @@ const TeamForm: React.FC<TeamFormProps> = ({
         } as TeamRequest);
         if (dataUpdate.error) {
           setRequestError(dataUpdate.error);
+          toast.error(dataUpdate.error);
           return;
+        } else {
+          toast.success("Team Updated Successfully");
         }
         break;
       }
@@ -122,6 +129,7 @@ const TeamForm: React.FC<TeamFormProps> = ({
     deleteTeamMutation.mutate({
       id: teamId ? teamId : 0,
     } as TeamRequest);
+    toast.success("Team Deleted Successfully");
     afterSave();
   };
 

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -7,6 +7,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { matchPath } from "../../utils/matchPath";
 import { Outlet } from "react-router-dom";
 import Header from "../Header/Header";
+import { ToastContainer } from "react-toastify";
 
 const Layout: React.FC<LayoutProps> = () => {
   const { user } = useAuth0();
@@ -14,7 +15,7 @@ const Layout: React.FC<LayoutProps> = () => {
   const [selectedItem, setSelectedItem] = useState("");
 
   const isBlacklisted = blackListRoutes.some((pattern) =>
-    matchPath(window.location.pathname, pattern, blackListExceptions),
+    matchPath(window.location.pathname, pattern, blackListExceptions)
   );
 
   return (
@@ -28,6 +29,18 @@ const Layout: React.FC<LayoutProps> = () => {
           <SideNav
             selectedItem={selectedItem}
             setSelectedItem={setSelectedItem}
+          />
+          <ToastContainer
+            position="bottom-right"
+            autoClose={4000}
+            hideProgressBar={false}
+            newestOnTop={false}
+            closeOnClick={false}
+            rtl={false}
+            pauseOnFocusLoss
+            draggable
+            pauseOnHover
+            theme="light"
           />
         </main>
       ) : (

--- a/client/src/pages/Forms/Forms.tsx
+++ b/client/src/pages/Forms/Forms.tsx
@@ -34,11 +34,6 @@ const ShareModal: React.FC<ShareModalProps> = ({
   onOpen,
 }) => (
   <Modal open={isOpen} onOpenChange={onOpen}>
-    <Modal.Button asChild className={styles.modalTrigger}>
-      <button onClick={() => onOpen(true)}>
-        <ShareButton />
-      </button>
-    </Modal.Button>
     <Modal.Content title="Share Form">
       <ShareForm afterClose={() => onOpen(false)} formLink={formLink} />
     </Modal.Content>


### PR DESCRIPTION
### Description

This PR introduces a minor change that will allow users to see comfirmation when a form is shared or when a league, seasons, etc is created, edited or deleted. It does using a [Toast](https://www.npmjs.com/package/react-toastify) component.

### Issue Link

[Jira Ticket](https://cascarita.atlassian.net/browse/CV-148)

### Screenshots
Screen Recording 2025-03-19 at 1.54.17 AM
### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [x] I have added test cases (if applicable)

### Additional Notes
