### PR TITLE
Feature: Add Stripe Url for Payment Intents

### DIFF
--- a/client/src/components/FormResponses/FormResponses.module.css
+++ b/client/src/components/FormResponses/FormResponses.module.css
@@ -70,3 +70,17 @@
   flex-direction: column;
   gap: 6px;
 }
+
+.stripePaymentButton {
+  background-color: #635bff;
+  color: white;
+  border-radius: 8px;
+  padding: 1rem 2rem;
+  cursor: pointer;
+  margin: 1.5rem 0;
+  transition: background-color 0.2s ease;
+}
+
+.stripePaymentButton:hover {
+  background-color: #5851db;
+}

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -93,6 +93,8 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
   const [status, setStatus] = useState<("approved" | "rejected" | "pending")[]>(
     []
   );
+  const [stripeUrls, setStripeUrls] = useState<(string | null)[]>([]);
+
   const [formResponsesData, setFormResponsesData] = useState<AnswerRecordMap>(
     []
   );
@@ -167,6 +169,7 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
       setPaymentIntentIds(paymentIntentIdsData);
       const statusData: ("approved" | "rejected" | "pending")[] = [];
       const paymentTypeData: string[] = [];
+      const stripeUrlsData: (string | null)[] = [];
       const formPayments = await getFormPayments(formId);
       await Promise.all(
         formPayments.map(
@@ -183,12 +186,14 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
             } else {
               paymentTypeData[index] = "Cash / Check";
             }
+
+            stripeUrlsData[index] = paymentData.stripe_url || null;
           }
         )
       );
-
       setStatus(statusData);
       setPaymentType(paymentTypeData);
+      setStripeUrls(stripeUrlsData);
     })();
   }, [formId]);
 
@@ -379,6 +384,20 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
                   </Modal.Button>
                   <Modal.Content maximize={true} title={user[index]}>
                     <FormResponseForm answers={response} />
+                    {stripeUrls[index] && (
+                      <PrimaryButton
+                        className={styles.stripePaymentButton}
+                        onClick={() => {
+                          if (stripeUrls[index]) {
+                            window.open(stripeUrls[index], "_blank");
+                          }
+                        }}
+                      >
+                        <p className={styles.btnTextDesktop}>
+                          View Stripe Payment
+                        </p>
+                      </PrimaryButton>
+                    )}
                   </Modal.Content>
                 </Modal>
               </td>

--- a/client/src/components/FormResponses/FormResponses.tsx
+++ b/client/src/components/FormResponses/FormResponses.tsx
@@ -93,7 +93,9 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
   const [status, setStatus] = useState<("approved" | "rejected" | "pending")[]>(
     []
   );
-  const [stripeUrls, setStripeUrls] = useState<(string | null)[]>([]);
+  const [stripePaymentIntentUrls, setStripePaymentIntentUrlsData] = useState<
+    (string | null)[]
+  >([]);
 
   const [formResponsesData, setFormResponsesData] = useState<AnswerRecordMap>(
     []
@@ -169,7 +171,7 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
       setPaymentIntentIds(paymentIntentIdsData);
       const statusData: ("approved" | "rejected" | "pending")[] = [];
       const paymentTypeData: string[] = [];
-      const stripeUrlsData: (string | null)[] = [];
+      const stripePaymentIntentUrlsData: (string | null)[] = [];
       const formPayments = await getFormPayments(formId);
       await Promise.all(
         formPayments.map(
@@ -187,13 +189,14 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
               paymentTypeData[index] = "Cash / Check";
             }
 
-            stripeUrlsData[index] = paymentData.stripe_url || null;
+            stripePaymentIntentUrlsData[index] =
+              paymentData.stripe_payment_intent_url || null;
           }
         )
       );
       setStatus(statusData);
       setPaymentType(paymentTypeData);
-      setStripeUrls(stripeUrlsData);
+      setStripePaymentIntentUrlsData(stripePaymentIntentUrlsData);
     })();
   }, [formId]);
 
@@ -384,12 +387,15 @@ const FormResponses = ({ formId, populateResponses }: FormResponsesProps) => {
                   </Modal.Button>
                   <Modal.Content maximize={true} title={user[index]}>
                     <FormResponseForm answers={response} />
-                    {stripeUrls[index] && (
+                    {stripePaymentIntentUrls[index] && (
                       <PrimaryButton
                         className={styles.stripePaymentButton}
                         onClick={() => {
-                          if (stripeUrls[index]) {
-                            window.open(stripeUrls[index], "_blank");
+                          if (stripePaymentIntentUrls[index]) {
+                            window.open(
+                              stripePaymentIntentUrls[index],
+                              "_blank"
+                            );
                           }
                         }}
                       >

--- a/client/src/components/FormResponses/types.ts
+++ b/client/src/components/FormResponses/types.ts
@@ -66,6 +66,7 @@ export interface FormPaymentType {
   updated_at: Date;
   user_stripe_account_id: number;
   response_document_id: string | null;
+  stripe_url: string | null;
 }
 
 export type AnswerRecordMap = Record<string, Answer>[];

--- a/client/src/components/FormResponses/types.ts
+++ b/client/src/components/FormResponses/types.ts
@@ -66,7 +66,7 @@ export interface FormPaymentType {
   updated_at: Date;
   user_stripe_account_id: number;
   response_document_id: string | null;
-  stripe_url: string | null;
+  stripe_payment_intent_url: string | null;
 }
 
 export type AnswerRecordMap = Record<string, Answer>[];

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -10,7 +10,6 @@ const createPayerUser = require("../utilityFunctions/createPayerUser");
 const FormPaymentController = function () {
   var getFormPaymentsByFormId = async function (form_id) {
     try {
-      let formPayments = [];
       let form = await Form.findOne({
         where: {
           document_id: form_id,
@@ -23,11 +22,9 @@ const FormPaymentController = function () {
         },
       });
 
-      formPayments = formPayments.concat(payments);
-
       return {
         success: true,
-        data: formPayments,
+        data: payments,
         status: 201,
       };
     } catch (error) {
@@ -385,7 +382,7 @@ const FormPaymentController = function () {
           payment.payment_method_id === 1
             ? `https://dashboard.stripe.com/payments/${payment.payment_intent_id}`
             : null;
-        console.log("Modified payment:", JSON.stringify(payment));
+        // console.log("Modified payment:", JSON.stringify(payment));
       });
 
       return formPayments;

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -214,16 +214,11 @@ const FormPaymentController = function () {
         return res.status(formPayments.success).json(formPayments.error);
       }
 
-      const data = formPayments.data.map((pyt) => {
-        return pyt.dataValues;
-      });
-      const completedFormPayment = data.filter(
+      const completedFormPayment = formPayments.data.filter(
         (payment) => payment.response_document_id,
       );
 
-      const formPaymentsUpdated = addStripeUrl(completedFormPayment);
-
-      return res.status(200).json(formPaymentsUpdated);
+      return res.status(200).json(completedFormPayment);
     } catch (error) {
       next(error);
     }
@@ -375,21 +370,6 @@ const FormPaymentController = function () {
     }
   };
 
-  var addStripeUrl = function (formPayments) {
-    try {
-      formPayments.forEach((payment) => {
-        payment.stripe_url =
-          payment.payment_method_id === 1
-            ? `https://dashboard.stripe.com/payments/${payment.payment_intent_id}`
-            : null;
-        // console.log("Modified payment:", JSON.stringify(payment));
-      });
-
-      return formPayments;
-    } catch (error) {
-      return formPayments;
-    }
-  };
   return {
     getFormPaymentsByFormId,
     connectResponseToFormPayment,

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -11,20 +11,19 @@ const FormPaymentController = function () {
   var getFormPaymentsByFormId = async function (form_id) {
     try {
       let formPayments = [];
-      let forms = await Form.findAll({
+      let form = await Form.findOne({
         where: {
           document_id: form_id,
         },
       });
 
-      for (let form of forms) {
-        let payments = await FormPayment.findAll({
-          where: {
-            form_id: form.id,
-          },
-        });
-        formPayments = formPayments.concat(payments);
-      }
+      let payments = await FormPayment.findAll({
+        where: {
+          form_id: form.id,
+        },
+      });
+
+      formPayments = formPayments.concat(payments);
 
       return {
         success: true,

--- a/server/controllers/formPayment.controller.js
+++ b/server/controllers/formPayment.controller.js
@@ -217,12 +217,16 @@ const FormPaymentController = function () {
         return res.status(formPayments.success).json(formPayments.error);
       }
 
-      const data = formPayments.data;
+      const data = formPayments.data.map((pyt) => {
+        return pyt.dataValues;
+      });
       const completedFormPayment = data.filter(
         (payment) => payment.response_document_id,
       );
 
-      return res.status(200).json(completedFormPayment);
+      const formPaymentsUpdated = addStripeUrl(completedFormPayment);
+
+      return res.status(200).json(formPaymentsUpdated);
     } catch (error) {
       next(error);
     }
@@ -374,6 +378,21 @@ const FormPaymentController = function () {
     }
   };
 
+  var addStripeUrl = function (formPayments) {
+    try {
+      formPayments.forEach((payment) => {
+        payment.stripe_url =
+          payment.payment_method_id === 1
+            ? `https://dashboard.stripe.com/payments/${payment.payment_intent_id}`
+            : null;
+        console.log("Modified payment:", JSON.stringify(payment));
+      });
+
+      return formPayments;
+    } catch (error) {
+      return formPayments;
+    }
+  };
   return {
     getFormPaymentsByFormId,
     connectResponseToFormPayment,

--- a/server/models/formpayment.js
+++ b/server/models/formpayment.js
@@ -102,6 +102,16 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
+      stripe_url: {
+        type: DataTypes.VIRTUAL,
+        get() {
+          const paymentIntentId = this.payment_intent_id;
+          const paymentMethod = this.payment_method_id;
+          return paymentMethod === 1
+            ? `https://dashboard.stripe.com/payments/${paymentIntentId}`
+            : null;
+        },
+      },
     },
 
     {

--- a/server/models/formpayment.js
+++ b/server/models/formpayment.js
@@ -102,12 +102,13 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
-      stripe_url: {
+      stripe_payment_intent_url: {
         type: DataTypes.VIRTUAL,
         get() {
           const paymentIntentId = this.payment_intent_id;
           const paymentMethod = this.payment_method_id;
-          return paymentMethod === 1
+          const stripePayment = 1;
+          return paymentMethod === stripePayment
             ? `https://dashboard.stripe.com/payments/${paymentIntentId}`
             : null;
         },


### PR DESCRIPTION
### Description

1. Added a `stripe_url` where it contains the link to the Payment Intent on the connected account's stripe dashboard .
2.  Added the `stripe_url` as a [virtual column](https://sequelize.org/docs/v6/core-concepts/getters-setters-virtuals/#virtual-fields) and used [`get()`](https://sequelize.org/docs/v6/core-concepts/getters-setters-virtuals/#getters) to set up the logic for the creation of the url. Shout out to @garcialuis for pointing me that direction. I think this is a WAY better way of updating query results with attributes we may need ! 
3. I did have to update the query to find the form `id` based of the form document id. For some reason we were using `findAll` but one `document_id` should only be linked to one form `id`.
4. Updated the front end to render a button to redirect users to stripe and see the transaction in more detail:
<img width="345" alt="image" src="https://github.com/user-attachments/assets/1682e694-d52b-4bbe-b2e8-f95125f2ab24" />


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
